### PR TITLE
feat: jwt 인증 로직 추가, refactor: popup 페이지 비지니스 로직 리펙토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.1",
-    "react-toastify": "^9.1.3"
+    "react-toastify": "^9.1.3",
+    "zustand": "^4.3.8"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ specifiers:
   vite: 4.3.5
   webpack: ^5.0.0
   ws: 8.13.0
+  zustand: ^4.3.8
 
 dependencies:
   '@fxts/core': 0.15.1
@@ -57,6 +58,7 @@ dependencies:
   react-icons: 4.8.0_react@18.2.0
   react-router-dom: 6.11.2_biqbaboplfbrettd7655fr4n2y
   react-toastify: 9.1.3_biqbaboplfbrettd7655fr4n2y
+  zustand: 4.3.8_react@18.2.0
 
 devDependencies:
   '@rollup/plugin-typescript': 11.1.1_sbfqscxoci6vmyg6dypa57mo3u
@@ -5837,3 +5839,19 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zustand/4.3.8_react@18.2.0:
+    resolution: {integrity: sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false

--- a/src/common/ui/Modal.tsx
+++ b/src/common/ui/Modal.tsx
@@ -20,6 +20,10 @@ import { useContext } from "react";
 import { cloneElement } from "react";
 import classNames from "classnames";
 import ModalCodeBlock from "@src/pages/popup/ui/ModalCodeBlock";
+import {
+  AuthModalContent,
+  AuthModalProps,
+} from "@src/pages/popup/ui/AuthModal";
 
 const ModalContext = createContext<{
   modalOpen: boolean;
@@ -144,6 +148,18 @@ const Content = ({ children, onClose }: ContentProps) => {
           ) {
             return cloneElement(child, { onClose: handleCloseModal });
           }
+          if (
+            isValidElement<AuthModalProps>(child) &&
+            child.type === AuthModalContent
+          ) {
+            return cloneElement(child, {
+              onClose: () => {
+                child.props.onClose();
+                handleCloseModal();
+              },
+            });
+          }
+
           return child;
         })}
       </section>

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -1,57 +1,20 @@
-import { useState } from "react";
 import { popupStyle } from "./styles/popup.css";
 import Search from "./ui/Search";
 import APIItem from "./ui/APIItem";
-import useGetAPIList from "./hooks/useGetAPIList";
 import useSearch from "./hooks/useSearch";
-import { useGETDocs } from "./api/docs";
-import { RequestProps } from "./ui/Request";
 import { vars } from "@src/common/ui/styles/theme.css";
-import { useNavigate } from "react-router-dom";
-import { useEffect } from "react";
 import { IoMdSettings as SettingIcon } from "react-icons/io";
-import { convertSelectedAPI } from "./util/convertSelectedAPI";
-import { API, APIList, Path } from "../content/modules/getAPIList";
+import useHandlePopup from "./hooks/Popup/useHandlePopup";
+import useHandleAuth from "./hooks/Popup/useHandleAuth";
+import AuthModal from "./ui/AuthModal";
 
 const Popup = () => {
-  const navigate = useNavigate();
+  const { apiList, filteredAPIList, onClickAPI, setFilteredAPIList } =
+    useHandlePopup();
 
-  // FIRST RENDER
-  const [apiList, setAPIList] = useState<APIList>({
-    endpoints: {},
-    tags: [],
-  });
-
-  const [pathInfo, setPathInfo] = useState<Path>({
-    host: "",
-    href: "",
-  });
-
-  const [filteredAPIList, setFilteredAPIList] = useState<APIList>({
-    endpoints: {},
-    tags: [],
-  });
-
-  useGetAPIList({ setAPIList, setPathInfo });
-  const { data } = useGETDocs(pathInfo);
-
-  // INTERACTION
-  // 1. 유저 > 검색어 입력
   const { search, onChange } = useSearch({ apiList, setFilteredAPIList });
-  const [selectedAPI, setSelectedAPI] = useState<RequestProps>(null);
 
-  const onClickAPI = (api: API) => {
-    setSelectedAPI({ ...convertSelectedAPI(data, api), host: pathInfo.host });
-  };
-
-  useEffect(() => {
-    selectedAPI &&
-      navigate("/request", {
-        state: {
-          ...selectedAPI,
-        },
-      });
-  }, [selectedAPI]);
+  const { authorized, onChangeAuth, onSaveAuth } = useHandleAuth();
 
   return (
     <div id="main" className={popupStyle.app}>
@@ -60,6 +23,11 @@ const Popup = () => {
           <button>
             <SettingIcon size={24} color="white" />
           </button>
+          <AuthModal
+            authorized={authorized}
+            onChange={onChangeAuth}
+            onSaveAuth={onSaveAuth}
+          />
         </div>
         <Search value={search} onChange={onChange} />
         <ul className={popupStyle.apiList}>

--- a/src/pages/popup/hooks/Popup/useHandleAuth.ts
+++ b/src/pages/popup/hooks/Popup/useHandleAuth.ts
@@ -1,0 +1,22 @@
+import { ChangeEvent } from "react";
+import { useState } from "react";
+import useAuthStore from "../../store/auth";
+
+const useHandleAuth = () => {
+  const [authorized, setAuthorized] = useState("");
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setAuthorized(e.target.value);
+  };
+
+  const setAuthToStore = useAuthStore((state) => state.setToken);
+
+  const onSaveAuth = () => {
+    chrome.storage.sync.set({ authorized });
+    setAuthToStore(authorized);
+  };
+
+  return { authorized, onChangeAuth: onChange, onSaveAuth };
+};
+
+export default useHandleAuth;

--- a/src/pages/popup/hooks/Popup/useHandlePopup.ts
+++ b/src/pages/popup/hooks/Popup/useHandlePopup.ts
@@ -1,0 +1,53 @@
+import { API, APIList, Path } from "@src/pages/content/modules/getAPIList";
+import { useState } from "react";
+import useGetAPIList from "../useGetAPIList";
+import { useGETDocs } from "../../api/docs";
+import { convertSelectedAPI } from "../../util/convertSelectedAPI";
+import useRouter from "../useRouter";
+
+const useHandlePopup = () => {
+  const { push } = useRouter();
+
+  // FIRST RENDER
+  const [apiList, setAPIList] = useState<APIList>({
+    endpoints: {},
+    tags: [],
+  });
+
+  const [pathInfo, setPathInfo] = useState<Path>({
+    host: "",
+    href: "",
+  });
+
+  const [filteredAPIList, setFilteredAPIList] = useState<APIList>({
+    endpoints: {},
+    tags: [],
+  });
+
+  // SERVER
+  // 1. API 리스트를 가져온다 > 사용자 웹 브라우저로부터
+  useGetAPIList({ setAPIList, setPathInfo });
+
+  // 2. 상세 API 리스트를 가져온다 > swagger 문서로부터
+  const { data: apiDocsData } = useGETDocs(pathInfo);
+
+  // INTERACTION
+  // 1. 사용자 > API 클릭 > API 상세 페이지로 이동
+  const onClickAPI = (api: API) => {
+    push("/request", {
+      ...convertSelectedAPI(apiDocsData, api),
+      host: pathInfo.host,
+    });
+  };
+
+  return {
+    apiList,
+    filteredAPIList,
+    apiDocsData,
+    pathInfo,
+    onClickAPI,
+    setFilteredAPIList,
+  };
+};
+
+export default useHandlePopup;

--- a/src/pages/popup/hooks/useRouter.ts
+++ b/src/pages/popup/hooks/useRouter.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useNavigate } from "react-router-dom";
+import { useMemo } from "react";
+
+const useRouter = () => {
+  const navigate = useNavigate();
+  return useMemo(() => {
+    return {
+      back(steps = 1) {
+        navigate(-steps);
+      },
+      push(path: RoutePath, state?: any) {
+        navigate(
+          {
+            pathname: path,
+          },
+          {
+            state,
+          }
+        );
+      },
+    };
+  }, [navigate]);
+};
+
+export default useRouter;
+
+export type RoutePath = "/request" | "/";

--- a/src/pages/popup/store/auth.ts
+++ b/src/pages/popup/store/auth.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface AuthStore {
+  token: string;
+  setToken: (token: string) => void;
+}
+
+const useAuthStore = create<AuthStore>((set) => ({
+  token: "",
+  setToken: (token: string) => set({ token }),
+}));
+
+export default useAuthStore;

--- a/src/pages/popup/styles/popup.css.ts
+++ b/src/pages/popup/styles/popup.css.ts
@@ -47,6 +47,7 @@ export const popupStyle = {
     justifyItems: "flex-end",
     justifyContent: "flex-end",
     padding: "10px 20px",
+    columnGap: "20px",
   }),
 
   tag: style({

--- a/src/pages/popup/ui/AuthModal.tsx
+++ b/src/pages/popup/ui/AuthModal.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import Input from "@src/common/ui/Input";
+import Modal from "@src/common/ui/Modal";
+import { ChangeEvent } from "react";
+import { FcLock as LockIcon } from "react-icons/fc";
+import { authModalStyle } from "./styles/auth.css";
+import Button from "@src/common/ui/Button";
+import { vars } from "@src/common/ui/styles/theme.css";
+
+export interface AuthModalProps {
+  authorized: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSaveAuth: () => void;
+  onClose?: () => void;
+}
+
+const AuthModal = ({ authorized, onChange, onSaveAuth }: AuthModalProps) => {
+  return (
+    <Modal>
+      <Modal.Trigger
+        as={
+          <button onClick={() => {}}>
+            <LockIcon size={24} />
+          </button>
+        }
+      />
+      <Modal.Content onClose={onSaveAuth}>
+        <AuthModalContent
+          {...{ authorized, onChange, onSaveAuth, onClose: onSaveAuth }}
+        />
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+export default AuthModal;
+
+interface AuthModalContentProps {
+  authorized: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onClose?: () => void;
+}
+
+export const AuthModalContent = ({
+  authorized,
+  onChange,
+  onClose,
+}: AuthModalContentProps) => {
+  return (
+    <div className={authModalStyle.modal}>
+      <h2 className={authModalStyle.mainDescription}>Setting Authorize</h2>
+      <section className={authModalStyle.inputWrapper}>
+        <span className={authModalStyle.inputDescription}>Bearer</span>
+        <Input value={authorized} onChange={onChange} />
+      </section>
+      <div className={authModalStyle.buttonWrapper}>
+        <Button
+          onClick={() => {
+            // onSaveAuth();
+            onClose && onClose();
+          }}
+          style={{ backgroundColor: vars.color.green }}
+        >
+          SAVE
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/popup/ui/Request.tsx
+++ b/src/pages/popup/ui/Request.tsx
@@ -21,6 +21,7 @@ import {
 } from "../util/apiGenerator";
 import useForm from "../hooks/useForm";
 import "react-toastify/dist/ReactToastify.css";
+import useAuthStore from "../store/auth";
 
 export interface RequestProps {
   method: Method;
@@ -37,6 +38,8 @@ const Request = () => {
   // FIRST RENDER
   const { method, params, path, body, host, description } = useLocation()
     .state as RequestProps;
+
+  const token = useAuthStore((state) => state.token);
 
   // INTERACTION
   // 1. 유저 > params, body 입력
@@ -77,11 +80,13 @@ const Request = () => {
         : acc;
     }, path);
     try {
+      const headers = token.length ? { Authorization: `Bearer ${token}` } : {};
       const response = await axios({
         method,
         url: host + transformPath,
         params: getQueryParams(params, formValues) ?? {},
         data: body ? getBody(body, formValues) : {},
+        headers,
       });
       setResponse(response.data);
     } catch (error) {

--- a/src/pages/popup/ui/styles/auth.css.ts
+++ b/src/pages/popup/ui/styles/auth.css.ts
@@ -1,0 +1,43 @@
+import { vars } from "@src/common/ui/styles/theme.css";
+import { style } from "@vanilla-extract/css";
+
+export const authModalStyle = {
+  modal: style({
+    marginTop: "40px",
+    backgroundColor: vars.color.darkGrey,
+    color: vars.color.white,
+    width: "300px",
+    height: "200px",
+    borderRadius: "10px",
+    padding: "20px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+  }),
+
+  mainDescription: style({
+    fontWeight: "bold",
+    display: "flex",
+    alignItems: "left",
+    color: vars.color.orange,
+  }),
+
+  inputWrapper: style({
+    marginTop: "20px",
+    display: "flex",
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "space-between",
+  }),
+
+  inputDescription: style({
+    width: "100px",
+    textAlign: "start",
+    color: vars.color.white,
+  }),
+
+  buttonWrapper: style({
+    width: "100%",
+    marginTop: "30px",
+  }),
+};

--- a/src/pages/popup/util/apiGenerator.test.ts
+++ b/src/pages/popup/util/apiGenerator.test.ts
@@ -39,7 +39,7 @@ describe("API 코드 생성", () => {
   };
 
   it("주어진 Param에 대해서 올바른 interface 타입을 생성한다", () => {
-    const expectedInterface = `interface RequestInterface {\n  param1: string;\n  param2: number;\n}`;
+    const expectedInterface = `interface RequestInterface {\n  param1: string;\n  param2: number;\n  token?: string;\n}`;
     const result = generateInterface(sampleParams);
 
     expect(result).toBe(expectedInterface);
@@ -55,7 +55,7 @@ describe("API 코드 생성", () => {
     expect(result).toContain(
       `const ${sampleAPI.method.toLowerCase()}API = async ({ ${sampleParams
         .map((param) => param.name)
-        .join(", ")} }: RequestInterface) => {`
+        .join(", ")}, token }: RequestInterface) => {`
     );
     expect(result).toContain(`method: "${sampleAPI.method}",`);
     expect(result).toContain(`url: "${sampleAPI.host}${sampleAPI.path}",`);
@@ -79,11 +79,15 @@ describe("API 코드 생성", () => {
       formValues: sampleFormValues,
     });
 
+    const queryParams = sampleParams.filter(
+      (param) => param.in === "query" || param.in === "path"
+    );
+    const args = queryParams.map((param) => param.name).join(", ");
+    const parameters = args.length > 0 ? `${args}, token` : "token";
+
     // 결과값의 패턴이 맞는지 확인
     expect(result).toContain(
-      `const ${sampleAPI.method.toLowerCase()}API = async ({ ${sampleParams
-        .map((param) => param.name)
-        .join(", ")} }: RequestInterface) => {`
+      `const ${sampleAPI.method.toLowerCase()}API = async ({ ${parameters} }: RequestInterface) => {`
     );
     expect(result).toContain(`method: "${sampleAPI.method}",`);
     expect(result).toContain(


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #64 
- PR의 메인 내용

1. jwt 입력 모달 추가
2. token 있으면 사용하도록 axios 로직 추가
3. token에 대한 axios request type 및 hedaer 추가
4. token에 대한 fetch request type 및 hedaer 추가
5. useRouter 추가
6. Popup 페이지 비지니스 로직 커스텀 훅으로 추상화

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] jwt 입력 할 수 있는 `AuthModal` 추가
- [x] 토큰 사용하도록 apiGenerator 코드 수정
- [x] 토큰 사용하도록 apiGenerator 테스트 코드 수정
- [x] Popup 페이지 비지니스 로직 커스텀 훅으로 추상화 -> `useHandlePopup`

## 📸 스크린샷 (선택)  

![image](https://github.com/whatsOver/swagger/assets/54137044/296c187b-cda4-4141-9226-39dfd7416960)
