### PR TITLE
fix: 기본 형식이 배열인 data response에 대한 처리 추가

### DIFF
--- a/src/common/util/typeGenerator.ts
+++ b/src/common/util/typeGenerator.ts
@@ -24,6 +24,10 @@ const jsonToTs = (
       const result = jsonToTs(`${key}Item`, json[0], true);
       interfaces = result.interfaceArray;
       rootInterfaceKey = result.rootInterfaceKey;
+    } else {
+      interfaces.push(
+        `export type ${capitalizedKey} = ${toTsType(json[0])}[];\n`
+      );
     }
   } else {
     interfaces.push(

--- a/src/pages/popup/util/apiGenerator.test.ts
+++ b/src/pages/popup/util/apiGenerator.test.ts
@@ -1,4 +1,4 @@
-import { Parameters, Schemas } from "../api/docs";
+import { Parameters } from "../api/docs";
 import {
   generateAxiosAPICode,
   generateFetchAPICode,


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #94
- PR의 메인 내용

1. 기본 형식이 배열인 data response에 대한 처리 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] 기본 형식이 배열인 data reponse에 대한 type generate 구문 추가
```ts
  if (Array.isArray(json)) {
    if (typeof json[0] === "object") {
      const result = jsonToTs(`${key}Item`, json[0], true);
      interfaces = result.interfaceArray;
      rootInterfaceKey = result.rootInterfaceKey;
    } else {
      interfaces.push(
        `export type ${capitalizedKey} = ${toTsType(json[0])}[];\n`
      );
    }
...
```

<br>

## 📸 스크린샷 (선택)  
