### PR TITLE
fix: 익스텐션 심사 사항 반영, refactor: 뒤로 가기에 대한 매번 상태값 바뀌던 오류 수정

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -41,7 +41,7 @@ const manifest: chrome.runtime.ManifestV3 = {
       matches: ["*://*/*"],
     },
   ],
-  permissions: ["activeTab", "scripting", "contextMenus"],
+  permissions: ["activeTab", "contextMenus"],
 };
 
 export default manifest;

--- a/src/pages/popup/hooks/Popup/useHandlePopup.ts
+++ b/src/pages/popup/hooks/Popup/useHandlePopup.ts
@@ -1,28 +1,22 @@
-import { API, APIList, Path } from "@src/pages/content/modules/getAPIList";
-import { useState } from "react";
+import { API } from "@src/pages/content/modules/getAPIList";
 import useGetAPIList from "../useGetAPIList";
 import { useGETDocs } from "../../api/docs";
 import { convertSelectedAPI } from "../../util/convertSelectedAPI";
 import useRouter from "../useRouter";
+import useSwaggerDocStore from "../../store/swaggerDoc";
 
 const useHandlePopup = () => {
   const { push } = useRouter();
 
   // FIRST RENDER
-  const [apiList, setAPIList] = useState<APIList>({
-    endpoints: {},
-    tags: [],
-  });
-
-  const [pathInfo, setPathInfo] = useState<Path>({
-    host: "",
-    href: "",
-  });
-
-  const [filteredAPIList, setFilteredAPIList] = useState<APIList>({
-    endpoints: {},
-    tags: [],
-  });
+  const {
+    apiList,
+    filteredAPIList,
+    pathInfo,
+    setAPIList,
+    setFilteredAPIList,
+    setPathInfo,
+  } = useSwaggerDocStore();
 
   // SERVER
   // 1. API 리스트를 가져온다 > 사용자 웹 브라우저로부터

--- a/src/pages/popup/hooks/useGetAPIList.ts
+++ b/src/pages/popup/hooks/useGetAPIList.ts
@@ -3,13 +3,12 @@ import {
   GET_API_LIST_RESULT,
   Path,
 } from "@src/pages/content/modules/getAPIList";
-import { SetStateAction } from "react";
-import { Dispatch } from "react";
 import { useEffect, useState } from "react";
+import useInitialStore from "../store/swaggerDoc";
 
 interface GetAPIListProps {
-  setAPIList: Dispatch<SetStateAction<APIList>>;
-  setPathInfo: Dispatch<SetStateAction<Path>>;
+  setAPIList: (apiList: APIList) => void;
+  setPathInfo: (pathInfo: Path) => void;
 }
 
 const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
@@ -46,7 +45,13 @@ const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
     );
   };
 
+  const { state, setState } = useInitialStore();
+
   useEffect(() => {
+    if (state === "loaded") {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       checkIfReceiverIsReady(tabs[0].id, (isReady) => {
@@ -54,6 +59,7 @@ const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
           getAPIList(tabs[0].id, (data) => {
             setAPIList(data.prList);
             setPathInfo(data.path);
+            setState("loaded");
           });
           setLoading(false);
         } else {
@@ -70,13 +76,14 @@ const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
             getAPIList(tab.id, (data) => {
               setAPIList(data.prList);
               setPathInfo(data.path);
+              setState("loaded");
             });
             setLoading(false);
           }
         })
       );
     });
-  }, []);
+  }, [state]);
 
   return { loading };
 };

--- a/src/pages/popup/hooks/useGetAPIList.ts
+++ b/src/pages/popup/hooks/useGetAPIList.ts
@@ -61,7 +61,9 @@ const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
             setPathInfo(data.path);
             setState("loaded");
           });
-          setLoading(false);
+          setTimeout(() => {
+            setLoading(false);
+          }, 500);
         } else {
           console.error("Error: Receiving end does not exist");
         }
@@ -78,7 +80,9 @@ const useGetAPIList = ({ setAPIList, setPathInfo }: GetAPIListProps) => {
               setPathInfo(data.path);
               setState("loaded");
             });
-            setLoading(false);
+            setTimeout(() => {
+              setLoading(false);
+            }, 500);
           }
         })
       );

--- a/src/pages/popup/store/swaggerDoc.ts
+++ b/src/pages/popup/store/swaggerDoc.ts
@@ -1,0 +1,38 @@
+import { APIList, Path } from "@src/pages/content/modules/getAPIList";
+import { create } from "zustand";
+
+interface SwaggerDocStore {
+  state: "initial" | "loaded";
+  setState: (state: "initial" | "loaded") => void;
+
+  apiList: APIList;
+  setAPIList: (apiList: APIList) => void;
+
+  filteredAPIList: APIList;
+  setFilteredAPIList: (apiList: APIList) => void;
+
+  pathInfo: Path;
+  setPathInfo: (pathInfo: Path) => void;
+}
+
+const useSwaggerDocStore = create<SwaggerDocStore>((set) => ({
+  state: "initial",
+  setState: (state: "initial" | "loaded") => set({ state }),
+  filteredAPIList: {
+    endpoints: {},
+    tags: [],
+  },
+  setFilteredAPIList: (filteredAPIList: APIList) => set({ filteredAPIList }),
+  apiList: {
+    endpoints: {},
+    tags: [],
+  },
+  setAPIList: (apiList: APIList) => set({ apiList }),
+  pathInfo: {
+    host: "",
+    href: "",
+  },
+  setPathInfo: (pathInfo: Path) => set({ pathInfo }),
+}));
+
+export default useSwaggerDocStore;


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #112
- PR의 메인 내용

1. 필요없는 permission 삭제
2. Request 페이지에서 뒤로 가기 시 매번 상태값 변경 하던 오류 수정
3. 페이지 로딩 상태 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] manifest의 scripting permission 삭제
- [x] zustand를 이용한 useState로 관리하던 상태값 이전
- [x] 최초 로딩에 대한 상태값 처리 로직 변경

<br>

## 📸 스크린샷 (선택)  
