### PR TITLE
fix: null에 대한 타입을 unknown 타입으로 생성 하도록 수정

### DIFF
--- a/src/common/util/typeGenerator.test.ts
+++ b/src/common/util/typeGenerator.test.ts
@@ -10,8 +10,9 @@ describe("toTsType", () => {
   });
 
   it('값이 null인 경우 "null"을 반환한다', () => {
-    // js의 typeof null은 "object"이다
-    expect(toTsType(null)).toEqual("object");
+    // null에 대한 typeof 연산은 "object"를 반환한다
+    // 이를 unknown으로 처리
+    expect(toTsType(null)).toEqual("unknown");
   });
 
   it("타입이 배열인 경우 배열 내의 첫 번째 요소 타입에 대한 배열 타입을 반환한다", () => {

--- a/src/common/util/typeGenerator.ts
+++ b/src/common/util/typeGenerator.ts
@@ -4,8 +4,8 @@ import { EMPTY_RESPONSE } from "@src/pages/popup/constants/status";
 
 const toTsType = (value: any): string => {
   const jsType = typeof value;
-  if (jsType === "number" || jsType === "boolean" || value === null)
-    return jsType;
+  if (jsType === "number" || jsType === "boolean") return jsType;
+  else if (jsType === "object" && value === null) return "unknown";
   else if (Array.isArray(value))
     return value.length > 0 ? `${toTsType(value[0])}[]` : "any[]";
   else if (jsType === "object") return "any";


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #111
- PR의 메인 내용

1. `null`에 대한 타입이 object로 제공 되던걸 `unknown`으로 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] toTsType > null -> unknown

<br>

## 📸 스크린샷 (선택)  
