### PR TITLE
fix: array type 생성 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-type-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "swagger chrome extension generate typescript, axios, fetch code",
   "license": "MIT",
   "author": {

--- a/src/common/util/typeGenerator.ts
+++ b/src/common/util/typeGenerator.ts
@@ -2,13 +2,30 @@
 
 import { EMPTY_RESPONSE } from "@src/pages/popup/constants/status";
 
+const isArrayType = (value: any): boolean =>
+  typeof value === "string" && value.startsWith("[") && value.endsWith("]");
+
+const checkArrayAndConvert = (value: any): any => {
+  try {
+    value = JSON.parse(value);
+  } catch (error) {
+    console.error(`Failed to parse JSON array: ${error}`);
+  }
+
+  return value;
+};
+
 const toTsType = (value: any): string => {
+  if (isArrayType(value)) {
+    value = checkArrayAndConvert(value);
+  }
   const jsType = typeof value;
+
   if (jsType === "number" || jsType === "boolean") return jsType;
   else if (jsType === "object" && value === null) return "unknown";
-  else if (Array.isArray(value))
+  else if (Array.isArray(value)) {
     return value.length > 0 ? `${toTsType(value[0])}[]` : "any[]";
-  else if (jsType === "object") return "any";
+  } else if (jsType === "object") return "any";
   else return "string";
 };
 

--- a/src/common/util/typeGenerator.ts
+++ b/src/common/util/typeGenerator.ts
@@ -11,7 +11,6 @@ const checkArrayAndConvert = (value: any): any => {
   } catch (error) {
     console.error(`Failed to parse JSON array: ${error}`);
   }
-
   return value;
 };
 

--- a/src/pages/popup/util/apiGenerator.ts
+++ b/src/pages/popup/util/apiGenerator.ts
@@ -1,6 +1,7 @@
 import { Method } from "axios";
 import { Parameters, Schemas } from "../api/docs";
 import { getParams } from "./request";
+import { typeConverter } from "./typeConverter";
 import { toTsType } from "@src/common/util/typeGenerator";
 
 const generateInterface = (
@@ -11,7 +12,7 @@ const generateInterface = (
   const interfaceItems = params
     ? params
         .filter((param) => param.in !== "body")
-        .map((param) => `  ${param.name}: ${toTsType(param.schema.type)};`)
+        .map((param) => `  ${param.name}: ${typeConverter(param.schema.type)};`)
         .join("\n")
     : "";
 

--- a/src/pages/popup/util/apiGenerator.ts
+++ b/src/pages/popup/util/apiGenerator.ts
@@ -1,7 +1,7 @@
 import { Method } from "axios";
 import { Parameters, Schemas } from "../api/docs";
 import { getParams } from "./request";
-import { typeConverter } from "./typeConverter";
+import { toTsType } from "@src/common/util/typeGenerator";
 
 const generateInterface = (
   params: Parameters[],
@@ -11,15 +11,13 @@ const generateInterface = (
   const interfaceItems = params
     ? params
         .filter((param) => param.in !== "body")
-        .map((param) => `  ${param.name}: ${typeConverter(param.schema.type)};`)
+        .map((param) => `  ${param.name}: ${toTsType(param.schema.type)};`)
         .join("\n")
     : "";
 
   const postData = body
     ? Object.keys(body.properties)
-        .map(
-          (key) => `    ${key}: ${typeConverter(body.properties[key].type)};`
-        )
+        .map((key) => `    ${key}: ${toTsType(body.properties[key].example)};`)
         .join("\n")
     : "";
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #132
- PR의 메인 내용

1. array type 생성 오류 수정

<br>

## 🔨 작업 사항 (필수)

- [x] scema.type을 사용 하던 로직을 타입 추출 로직으로 변경
- [x] toTsType의 배열 체크 로직 추가
```ts
const isArrayType = (value: any): boolean =>
  typeof value === "string" && value.startsWith("[") && value.endsWith("]");

const checkArrayAndConvert = (value: any): any => {
  try {
    value = JSON.parse(value);
  } catch (error) {
    console.error(`Failed to parse JSON array: ${error}`);
  }
  return value;
};
```

<br>

## 📸 스크린샷 (선택)  
