### PR TITLE
fix: axios api url에 template literal 사용 되도록 수정

### DIFF
--- a/src/pages/popup/util/apiGenerator.test.ts
+++ b/src/pages/popup/util/apiGenerator.test.ts
@@ -69,7 +69,9 @@ describe("API 코드 생성", () => {
         .join(", ")}, token }: RequestInterface) => {`
     );
     expect(result).toContain(`method: "${sampleAPI.method}",`);
-    expect(result).toContain(`url: "${sampleAPI.host}${sampleAPI.path}",`);
+    expect(result).toContain(
+      `url: "${sampleAPI.host}${sampleAPI.path.replace("{", "${")}",`
+    );
     expect(result).toContain(`params: { ${getParams(sampleParams)} },`);
     expect(result).toContain(
       `data: ${JSON.stringify(

--- a/src/pages/popup/util/apiGenerator.ts
+++ b/src/pages/popup/util/apiGenerator.ts
@@ -59,6 +59,9 @@ const generateAxiosAPICode = ({
     ? `${args.length > 0 ? `${args}, ` : ""}${method}Data`
     : args;
 
+  // path에 있는 {param}을 ${param}으로 변경
+  const dynamicPath = path.replace(/{/g, "${");
+
   const parameters = bodyArgs.length > 0 ? `${bodyArgs}, token` : "token";
 
   const axiosData = body ? `${method}Data` : "{}";
@@ -73,7 +76,7 @@ const generateAxiosAPICode = ({
 const ${method.toLowerCase()}API = async ({ ${parameters} }: ${interfaceName}) => {
   const { data } = await axios${responseInterface}({
     method: "${method}",
-    url: "${host}${path}",
+    url: "${host}${dynamicPath}",
     params: { ${args} },
     data: ${axiosData},
     headers: token ? { 'Authorization': \`Bearer \${token}\` } : {}


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #147
- PR의 메인 내용

1. axios url에 template literal 사용되지 않던 오류 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] url에 query param 제대로 적용되지 않던 오류 수정

<br>

## 📸 스크린샷 (선택)  
