### PR TITLE
fix: axios params에 path param 까지 포함되던 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-type-generator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "swagger chrome extension generate typescript, axios, fetch code",
   "license": "MIT",
   "author": {

--- a/src/pages/popup/util/apiGenerator.test.ts
+++ b/src/pages/popup/util/apiGenerator.test.ts
@@ -5,7 +5,7 @@ import {
   generateInterface,
   objectToQueryString,
 } from "./apiGenerator";
-import { getBody, getParams } from "./request";
+import { getBody, getParams, getQueryParamsArray } from "./request";
 
 describe("API 코드 생성", () => {
   const sampleParams: Parameters[] = [
@@ -72,7 +72,9 @@ describe("API 코드 생성", () => {
     expect(result).toContain(
       `url: "${sampleAPI.host}${sampleAPI.path.replace("{", "${")}",`
     );
-    expect(result).toContain(`params: { ${getParams(sampleParams)} },`);
+    expect(result).toContain(
+      `params: { ${getQueryParamsArray(sampleParams)} },`
+    );
     expect(result).toContain(
       `data: ${JSON.stringify(
         sampleAPI.body ? getBody(sampleAPI.body, sampleFormValues) : {}

--- a/src/pages/popup/util/apiGenerator.ts
+++ b/src/pages/popup/util/apiGenerator.ts
@@ -1,6 +1,6 @@
 import { Method } from "axios";
 import { Parameters, Schemas } from "../api/docs";
-import { getParams } from "./request";
+import { getParams, getQueryParamsArray } from "./request";
 import { typeConverter } from "./typeConverter";
 import { toTsType } from "@src/common/util/typeGenerator";
 
@@ -77,7 +77,7 @@ const ${method.toLowerCase()}API = async ({ ${parameters} }: ${interfaceName}) =
   const { data } = await axios${responseInterface}({
     method: "${method}",
     url: "${host}${dynamicPath}",
-    params: { ${args} },
+    params: { ${getQueryParamsArray(params)} },
     data: ${axiosData},
     headers: token ? { 'Authorization': \`Bearer \${token}\` } : {}
   });

--- a/src/pages/popup/util/request.test.ts
+++ b/src/pages/popup/util/request.test.ts
@@ -68,7 +68,7 @@ describe("getParams", () => {
       },
       {
         name: PARAM2,
-        in: "path",
+        in: "query",
         description: "차단 해제를 할 북마크 ID 값",
         required: true,
         schema: {
@@ -79,11 +79,14 @@ describe("getParams", () => {
       },
     ];
 
+    const withoutPathParam: Parameters[] = params.filter(
+      (param) => param.in !== "path"
+    );
     // WHEN
-    const result = getParams(params);
+    const result = getParams(withoutPathParam);
 
     // THEN
-    expect(result).toEqual(`${PARAM1}, ${PARAM2}`);
+    expect(result).toEqual(`${PARAM2}`);
   });
 });
 

--- a/src/pages/popup/util/request.ts
+++ b/src/pages/popup/util/request.ts
@@ -22,6 +22,16 @@ const getParams = (params: Parameters[]) =>
     (params) => params.join(", ")
   );
 
+const getQueryParamsArray = (params: Parameters[]) =>
+  pipe(
+    params,
+    filter((param) => param.in !== "body"),
+    filter((param) => param.in === "query"),
+    map((param) => param.name),
+    toArray,
+    (params) => params.join(", ")
+  );
+
 const replacePathParams = (path: string, formValues: FormValues) =>
   pipe(
     path.split("/"),
@@ -44,6 +54,7 @@ const getRequestBodyKey = (body: Schemas) =>
 
 export {
   getQueryParams,
+  getQueryParamsArray,
   getParams,
   replacePathParams,
   getBody,


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #164
- PR의 메인 내용

1. axios params에 path param 까지 포함되던 오류 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] getQueryParamsArray를 통해 queryParam만 포함 되도록 수정

<br>

## 📸 스크린샷 (선택)  
