### PR TITLE
fix: react query params가 없는 경우에 대한 처리 오류 수정

### DIFF
--- a/src/pages/popup/util/queryGeneartor.test.ts
+++ b/src/pages/popup/util/queryGeneartor.test.ts
@@ -1,10 +1,122 @@
 import {
   GenerateReactQueryHookProps,
+  generateQueryInterface,
+  generateQueryKey,
   generateReactQueryHook,
 } from "./queryGenerator";
 
+describe("generateQueryKey", () => {
+  it("params가 없는 경우", () => {
+    // given
+    const params = [];
+
+    // when
+    const result = generateQueryKey(params);
+
+    // then
+    expect(result).toBe("");
+  });
+
+  it("params가 있는 경우", () => {
+    // given
+    const params = [
+      {
+        name: "param1",
+        in: "path",
+        description: "",
+        required: true,
+        schema: { type: "string" },
+      },
+      {
+        name: "param2",
+        in: "query",
+        description: "",
+        required: true,
+        schema: { type: "number" },
+      },
+      {
+        name: "param3",
+        in: "query",
+        description: "",
+        required: true,
+        schema: { type: "boolean" },
+      },
+    ];
+
+    // when
+    const result = generateQueryKey(params);
+
+    // then
+    expect(result).toBe("param1,param2,param3");
+  });
+});
+
+describe("interface를 생성하는 generateQueryInterface", () => {
+  it("params가 없는 경우", () => {
+    // given
+    const apiFunctionName = "getData";
+    const params = [];
+
+    // when
+    const result = generateQueryInterface(apiFunctionName, params);
+
+    // then
+    expect(result).toEqual({
+      interfaceStr: `
+export interface GetDataRequest {
+  token?: string;
+}`,
+      paramsInterface: "GetDataRequest",
+    });
+  });
+
+  it("params가 있는 경우", () => {
+    // given
+    const apiFunctionName = "getData";
+    const params = [
+      {
+        name: "param1",
+        in: "path",
+        description: "",
+        required: true,
+        schema: { type: "string" },
+      },
+      {
+        name: "param2",
+        in: "query",
+        description: "",
+        required: true,
+        schema: { type: "number" },
+      },
+      {
+        name: "param3",
+        in: "query",
+        description: "",
+        required: true,
+        schema: { type: "boolean" },
+      },
+    ];
+
+    // when
+    const result = generateQueryInterface(apiFunctionName, params);
+
+    // then
+    expect(result).toEqual({
+      paramsInterface: "GetDataRequest",
+      interfaceStr: `
+export interface GetDataRequest {
+  param1: string;
+  param2: number;
+  param3: boolean;
+  token?: string;
+}`,
+    });
+  });
+});
+
 describe("generateReactQueryHook", () => {
-  it("GET 방식에 대한 useQuery 훅을 생성", () => {
+  it("GET 방식에 대한 useQuery 훅을 생성 (params가 있는 경우)", () => {
+    // given
     const api: Pick<GenerateReactQueryHookProps, "api">["api"] = {
       method: "GET",
       params: [
@@ -19,8 +131,10 @@ describe("generateReactQueryHook", () => {
     };
     const apiFunctionName = "getData";
 
+    // when
     const result = generateReactQueryHook({ api, apiFunctionName });
 
+    // then
     expect(result).toBe(`
 export interface GetDataRequest {
   param1: string;
@@ -35,7 +149,60 @@ export const useGetDataQuery = (params: GetDataRequest) => {
 `);
   });
 
-  it("POST 방식에 대한 useMutation 훅을 생성", () => {
+  it("GET 방식에 대한 useQuery 훅을 생성 (params가 없는 경우)", () => {
+    // given
+    const api: Pick<GenerateReactQueryHookProps, "api">["api"] = {
+      method: "GET",
+      params: [],
+    };
+    const apiFunctionName = "getData";
+
+    // when
+    const result = generateReactQueryHook({ api, apiFunctionName });
+
+    // then
+    expect(result).toBe(`
+export interface GetDataRequest {
+  token?: string;
+}
+
+const GetDataKey = (params: GetDataRequest) => ['GET'];
+
+export const useGetDataQuery = (params: GetDataRequest) => {
+  return useQuery(GetDataKey(params), async () => getData(params));
+};
+`);
+  });
+  it("POST 방식에 대한 useMutation 훅을 생성 (params가 있는 경우)", () => {
+    const api: Pick<GenerateReactQueryHookProps, "api">["api"] = {
+      method: "POST",
+      params: [
+        {
+          name: "param1",
+          in: "path",
+          description: "",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+    };
+    const apiFunctionName = "postData";
+
+    const result = generateReactQueryHook({ api, apiFunctionName });
+
+    expect(result).toBe(`
+export interface PostDataRequest {
+  param1: string;
+  token?: string;
+}
+
+export const usePostDataMutation = (params: PostDataRequest) => {
+  return useMutation(postData);
+};
+`);
+  });
+
+  it("POST 방식에 대한 useMutation 훅을 생성 (params가 없는 경우)", () => {
     const api: Pick<GenerateReactQueryHookProps, "api">["api"] = {
       method: "POST",
       params: [],
@@ -45,7 +212,11 @@ export const useGetDataQuery = (params: GetDataRequest) => {
     const result = generateReactQueryHook({ api, apiFunctionName });
 
     expect(result).toBe(`
-export const usePostDataMutation = () => {
+export interface PostDataRequest {
+  token?: string;
+}
+
+export const usePostDataMutation = (params: PostDataRequest) => {
   return useMutation(postData);
 };
 `);

--- a/src/pages/popup/util/queryGenerator.ts
+++ b/src/pages/popup/util/queryGenerator.ts
@@ -9,15 +9,14 @@ const generateQueryKey = (params: Parameters[]) => {
     .join(",");
 };
 
-const generateInterface = (
+const generateQueryInterface = (
   apiFunctionName: string,
-  params: Parameters[],
-  queryKey: string
+  params: Parameters[]
 ) => {
   const capitalizedFunctionName =
     apiFunctionName.charAt(0).toUpperCase() + apiFunctionName.slice(1);
 
-  const paramsInterface = queryKey ? `${capitalizedFunctionName}Request` : "";
+  const paramsInterface = `${capitalizedFunctionName}Request`;
 
   const interfaceItems = params
     ? params
@@ -58,19 +57,22 @@ const generateReactQueryHook = ({
   const capitalizedFunctionName =
     apiFunctionName.charAt(0).toUpperCase() + apiFunctionName.slice(1);
 
-  const queryKey = generateQueryKey(params);
-
-  const { paramsInterface, interfaceStr } = generateInterface(
+  const { paramsInterface, interfaceStr } = generateQueryInterface(
     capitalizedFunctionName,
-    params,
-    queryKey
+    params
   );
 
-  const queryKeysWithParams = queryKey
-    .split(",")
-    .map((key) => `params.${key}`)
-    .join(", ");
-  const queryKeyFunctionString = `const ${capitalizedFunctionName}Key = (params: ${paramsInterface}) => ['${method}', ${queryKeysWithParams}];`;
+  // queryKey 함수를 생성
+  const queryKey = generateQueryKey(params);
+  const queryKeysWithParams = queryKey.length
+    ? queryKey
+        .split(",")
+        .map((key) => `params.${key}`)
+        .join(", ")
+    : "";
+  const queryKeyFunctionString = `const ${capitalizedFunctionName}Key = (params: ${paramsInterface}) => ['${method}'${
+    queryKeysWithParams.length ? ", " + queryKeysWithParams : ""
+  }];`;
 
   const queryKeyString = `${capitalizedFunctionName}Key(params)`;
 
@@ -82,12 +84,12 @@ export const use${capitalizedFunctionName}Query = (params: ${paramsInterface}) =
 };
 `;
   } else {
-    return `${interfaceStr}
-export const use${capitalizedFunctionName}Mutation = () => {
+    return `${interfaceStr}\n
+export const use${capitalizedFunctionName}Mutation = (params: ${paramsInterface}) => {
   return useMutation(${apiFunctionName});
 };
 `;
   }
 };
 
-export { generateReactQueryHook };
+export { generateQueryKey, generateQueryInterface, generateReactQueryHook };


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #167
- PR의 메인 내용

1. react query params가 없는 처리 추가
2. test 케이스 추가(params 없는 경우) 및 분리

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] queryKey, params 생성 방식 수정
- [x] test 케이스 given, when, then 방식으로 수정

<br>

## 📸 스크린샷 (선택)  
