### PR TITLE
스키마로부터 직접 api 응답에 대한 스키마를 추출할 수 있도록 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 
 # compiled
 utils/reload/injections/*.js
+utils/reload/initReloadServer.js
 public/manifest.json

--- a/src/entities/docs/model/types/docs.ts
+++ b/src/entities/docs/model/types/docs.ts
@@ -1,5 +1,6 @@
 import {
   ContentType,
+  DetailSchema,
   Information,
   Parameters,
   Schemas,
@@ -49,6 +50,7 @@ export interface API {
   path: string;
   summary: string;
   description: string;
+  detailSchema?: DetailSchema;
 }
 
 export interface APIWithParamsOrBody extends API {

--- a/src/entities/docs/model/types/docs.ts
+++ b/src/entities/docs/model/types/docs.ts
@@ -59,6 +59,7 @@ export interface APIWithParamsOrBody extends API {
   contentType: ContentType;
   params?: Parameters[];
   body?: Schemas;
+  typeInfo?: DetailSchema;
 }
 
 export interface APIWithParamsAndBodyAndHost extends APIWithParamsOrBody {

--- a/src/entities/docs/model/types/docs.ts
+++ b/src/entities/docs/model/types/docs.ts
@@ -59,7 +59,7 @@ export interface APIWithParamsOrBody extends API {
   contentType: ContentType;
   params?: Parameters[];
   body?: Schemas;
-  typeInfo?: DetailSchema;
+  detailSchema?: DetailSchema;
 }
 
 export interface APIWithParamsAndBodyAndHost extends APIWithParamsOrBody {

--- a/src/entities/swagger/types/index.ts
+++ b/src/entities/swagger/types/index.ts
@@ -20,6 +20,28 @@ export type SwaggerFormat =
   | "date-time"
   | "password";
 
+export type RefSchema = {
+  $ref: string;
+};
+
+export type RefArraySchema = {
+  type: "array";
+  items: RefSchema;
+};
+
+export interface SchemaInfo {
+  schema: string;
+  typeName: string;
+  properties: Record<string, unknown>;
+  required: string[];
+  type: string;
+}
+
+export interface DetailSchema {
+  requestType: SchemaInfo | null;
+  responseType: SchemaInfo | null;
+}
+
 export interface Schema {
   title: string;
   type: string;
@@ -83,15 +105,6 @@ export type ContentType =
   | "multipart/form-data"
   | "application/x-www-form-urlencoded"
   | "*/*";
-
-type RefSchema = {
-  $ref: string;
-};
-
-type RefArraySchema = {
-  type: "array";
-  items: RefSchema;
-};
 
 export type DefaultComplexSchema = {
   title: string;

--- a/src/features/api-generate/module/utils/apiTransform.test.ts
+++ b/src/features/api-generate/module/utils/apiTransform.test.ts
@@ -115,6 +115,16 @@ describe("convertSelectedAPI", () => {
       params: [],
       body: null,
       contentType: "application/json",
+      detailSchema: {
+        requestType: null,
+        responseType: {
+          properties: {},
+          required: [],
+          schema: "#/components/schemas/RealTimeSearchesView",
+          type: "object",
+          typeName: "RealTimeSearchesView",
+        },
+      },
     });
   });
 
@@ -152,6 +162,31 @@ describe("convertSelectedAPI", () => {
         required: ["files"],
       },
       contentType: "multipart/form-data",
+      detailSchema: {
+        requestType: {
+          properties: {
+            files: {
+              items: {
+                format: "binary",
+                type: "string",
+              },
+              title: "Files",
+              type: "array",
+            },
+          },
+          required: ["files"],
+          schema: "inline",
+          type: "object",
+          typeName: "inline",
+        },
+        responseType: {
+          properties: {},
+          required: [],
+          schema: "#/components/schemas/MediaListView",
+          type: "object",
+          typeName: "MediaListView",
+        },
+      },
     });
   });
 });

--- a/src/features/api-generate/module/utils/apiTransform.ts
+++ b/src/features/api-generate/module/utils/apiTransform.ts
@@ -95,9 +95,9 @@ const extractSchemaInfo = (
     return {
       schema: schema.$ref,
       typeName,
-      properties: schemaData.properties || {},
-      required: schemaData.required || [],
-      type: schemaData.type || "object",
+      properties: schemaData?.properties || {},
+      required: schemaData?.required || [],
+      type: schemaData?.type || "object",
     };
   }
 

--- a/src/features/api-generate/module/utils/apiTransform.ts
+++ b/src/features/api-generate/module/utils/apiTransform.ts
@@ -12,6 +12,10 @@ import {
   SwaggerDocs,
 } from "@/entities/swagger/types";
 import { Method } from "axios";
+import { FormSchemaProperty } from "../hooks/useApiAddForm";
+
+// $ref에서 타입 이름 추출하는 유틸리티 함수
+const extractTypeNameFromRef = (ref: string): string => ref.split("/")[3];
 
 export const transformApiFromSwagger = (
   data: SwaggerDocs,
@@ -36,7 +40,7 @@ export const transformApiFromSwagger = (
     contentType = Object.keys(requestBody.content)[0] as ContentType;
     const schema = requestBody.content[contentType].schema;
     if ("$ref" in schema) {
-      schemaName = schema.$ref.split("/")[3];
+      schemaName = extractTypeNameFromRef(schema.$ref);
       body = data.components.schemas[schemaName];
     }
     if (
@@ -45,7 +49,7 @@ export const transformApiFromSwagger = (
       "items" in schema &&
       "$ref" in schema.items
     ) {
-      schemaName = schema.items.$ref.split("/")[3];
+      schemaName = extractTypeNameFromRef(schema.items.$ref);
       body = data.components.schemas[schemaName];
     }
     if ("default" in schema) {
@@ -89,25 +93,107 @@ const extractSchemaInfo = (
   components: SwaggerDocs["components"]
 ): SchemaInfo => {
   if ("$ref" in schema) {
-    const typeName = schema.$ref.split("/")[3];
+    const typeName = extractTypeNameFromRef(schema.$ref);
     const schemaData = components.schemas[typeName];
+
+    const properties = schemaData?.properties || {};
+    const processedProperties = processNestedProperties(properties, components);
 
     return {
       schema: schema.$ref,
       typeName,
-      properties: schemaData?.properties || {},
+      properties: processedProperties,
       required: schemaData?.required || [],
       type: schemaData?.type || "object",
     };
   }
 
+  const properties = (schema as Schema).properties || {};
+  const processedProperties = processNestedProperties(properties, components);
+
   return {
     schema: "inline",
     typeName: "inline",
-    properties: (schema as Schema).properties || {},
+    properties: processedProperties,
     required: (schema as Schema).required || [],
     type: (schema as Schema).type || "object",
   };
+};
+
+const processNestedProperties = (
+  properties: Record<string, unknown>,
+  components: SwaggerDocs["components"]
+): Record<string, unknown> => {
+  const processed: Record<string, unknown> = {};
+
+  Object.entries(properties).forEach(([key, value]) => {
+    if (typeof value === "object" && value !== null) {
+      const prop = value as FormSchemaProperty;
+
+      if (prop.$ref) {
+        const typeName = extractTypeNameFromRef(prop.$ref);
+        const schemaData = components.schemas[typeName];
+
+        if (schemaData?.properties) {
+          const expandedProperties = processNestedProperties(
+            schemaData.properties,
+            components
+          );
+
+          processed[key] = {
+            type: "object",
+            properties: expandedProperties,
+            required: schemaData.required || [],
+            $ref: prop.$ref,
+          };
+        } else {
+          processed[key] = value;
+        }
+      } else if (prop.type === "array" && prop.items) {
+        const processedItems = processArrayItems(prop.items, components);
+        processed[key] = {
+          ...prop,
+          items: processedItems,
+        };
+      } else {
+        processed[key] = value;
+      }
+    } else {
+      processed[key] = value;
+    }
+  });
+
+  return processed;
+};
+
+const processArrayItems = (
+  items: unknown,
+  components: SwaggerDocs["components"]
+): unknown => {
+  if (typeof items === "object" && items !== null) {
+    const itemProp = items as FormSchemaProperty;
+
+    if (itemProp.$ref) {
+      const typeName = extractTypeNameFromRef(itemProp.$ref);
+      const schemaData = components.schemas[typeName];
+
+      if (schemaData?.properties) {
+        const expandedProperties = processNestedProperties(
+          schemaData.properties,
+          components
+        );
+
+        return {
+          type: "object",
+          properties: expandedProperties,
+          required: schemaData.required || [],
+          $ref: itemProp.$ref,
+        };
+      }
+    }
+  }
+
+  return items;
 };
 
 const extractRequestType = (

--- a/src/features/api-generate/module/utils/apiTransform.ts
+++ b/src/features/api-generate/module/utils/apiTransform.ts
@@ -2,6 +2,12 @@ import { API, APIWithParamsOrBody } from "@/entities/docs/model/types/docs";
 import {
   ContentType,
   DefaultComplexSchema,
+  DetailSchema,
+  Information,
+  RefArraySchema,
+  RefSchema,
+  Schema,
+  SchemaInfo,
   Schemas,
   SwaggerDocs,
 } from "@/entities/swagger/types";
@@ -50,6 +56,8 @@ export const transformApiFromSwagger = (
     }
   }
 
+  const detailSchema = extractTypeSchemaInfo(data, api);
+
   return {
     endpoint: `${method} ${path}`,
     method,
@@ -59,6 +67,7 @@ export const transformApiFromSwagger = (
     params: parameters,
     body,
     contentType,
+    detailSchema,
   };
 };
 
@@ -74,3 +83,72 @@ function transformDefaultComplexSchema(schema: DefaultComplexSchema): Schemas {
 
   return { type: "object", required, properties };
 }
+
+const extractSchemaInfo = (
+  schema: RefSchema | RefArraySchema | DefaultComplexSchema | Schema,
+  components: SwaggerDocs["components"]
+): SchemaInfo => {
+  if ("$ref" in schema) {
+    const typeName = schema.$ref.split("/")[3];
+    const schemaData = components.schemas[typeName];
+
+    return {
+      schema: schema.$ref,
+      typeName,
+      properties: schemaData.properties || {},
+      required: schemaData.required || [],
+      type: schemaData.type || "object",
+    };
+  }
+
+  return {
+    schema: "inline",
+    typeName: "inline",
+    properties: (schema as Schema).properties || {},
+    required: (schema as Schema).required || [],
+    type: (schema as Schema).type || "object",
+  };
+};
+
+const extractRequestType = (
+  methodData: Information,
+  components: SwaggerDocs["components"]
+): SchemaInfo | null => {
+  const requestBody = methodData?.requestBody;
+  if (!requestBody) return null;
+
+  const contentType = Object.keys(requestBody.content)[0] as ContentType;
+  const schema = requestBody.content[contentType]?.schema;
+  if (!schema) return null;
+
+  return extractSchemaInfo(schema, components);
+};
+
+const extractResponseType = (
+  methodData: Information,
+  components: SwaggerDocs["components"]
+): SchemaInfo | null => {
+  const responses = methodData?.responses;
+  if (!responses) return null;
+
+  const successResponse =
+    responses["200"] || responses["201"] || responses["202"];
+  if (!successResponse?.content) return null;
+
+  const contentType = Object.keys(successResponse.content)[0] as ContentType;
+  const schema = successResponse.content[contentType]?.schema;
+  if (!schema) return null;
+
+  return extractSchemaInfo(schema, components);
+};
+
+// reqeust, response Schema 추출
+const extractTypeSchemaInfo = (data: SwaggerDocs, api: API): DetailSchema => {
+  const pathData = data.paths[api.path];
+  const methodData = pathData[api.method.toLowerCase() as Method];
+
+  return {
+    requestType: extractRequestType(methodData, data.components),
+    responseType: extractResponseType(methodData, data.components),
+  };
+};

--- a/src/features/auth/ui/auth-modal/AuthModal.tsx
+++ b/src/features/auth/ui/auth-modal/AuthModal.tsx
@@ -3,6 +3,7 @@ import Button from "@/shared/ui/Button";
 import Input from "@/shared/ui/Input";
 import Modal from "@/shared/ui/Modal";
 import { vars } from "@/shared/ui/styles/theme.css";
+import { noop } from "@/shared/util/common";
 import { ChangeEvent } from "react";
 import { FcLock as LockIcon } from "react-icons/fc";
 import { authModalStyle } from "./auth.css";
@@ -19,7 +20,7 @@ const AuthModal = ({ authorized, onChange, onSaveAuth }: AuthModalProps) => {
     <Modal>
       <Modal.Trigger
         as={
-          <button onClick={() => {}}>
+          <button onClick={noop}>
             <LockIcon size={24} />
           </button>
         }

--- a/src/features/request-api/module/hooks/useHandleRequest.ts
+++ b/src/features/request-api/module/hooks/useHandleRequest.ts
@@ -6,13 +6,14 @@ import { checkPathStartWithHttp } from "@/shared/util/api/api";
 import axios, { RawAxiosRequestHeaders } from "axios";
 import { FormEvent, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { Mode } from "../requestReducer";
 import { generateFormData, getBody, getQueryParams } from "../utils/request";
 import useForm, { FormValues, ReturnUseForm } from "./useForm";
 
 interface HandleRequest {
   api: APIWithParamsAndBodyAndHost | null;
-  setMode: React.Dispatch<React.SetStateAction<Mode>>;
+  setMode: React.Dispatch<
+    React.SetStateAction<"RESPONSE" | "ERROR" | "LOADING">
+  >;
   initialFormValues?: FormValues;
   onSuccess?: (request: unknown, response: unknown) => void;
 }

--- a/src/features/request-api/module/hooks/useHandleRequest.ts
+++ b/src/features/request-api/module/hooks/useHandleRequest.ts
@@ -2,11 +2,11 @@ import { EMPTY_RESPONSE } from "@/entities/api/config/status";
 import { useAuthStore } from "@/entities/auth/model/auth-store";
 import { APIWithParamsAndBodyAndHost } from "@/entities/docs/model/types/docs";
 import { Schemas } from "@/entities/swagger/types";
-import { Mode } from "@/pages/popup/pages/RequestPage/RequestPage";
 import { checkPathStartWithHttp } from "@/shared/util/api/api";
 import axios, { RawAxiosRequestHeaders } from "axios";
 import { FormEvent, useEffect, useState } from "react";
 import { toast } from "react-toastify";
+import { Mode } from "../requestReducer";
 import { generateFormData, getBody, getQueryParams } from "../utils/request";
 import useForm, { FormValues, ReturnUseForm } from "./useForm";
 

--- a/src/features/request-api/module/requestReducer.ts
+++ b/src/features/request-api/module/requestReducer.ts
@@ -1,0 +1,92 @@
+export type Mode = ApiMode | SchemaMode;
+
+export type ApiMode =
+  | "RESPONSE"
+  | "TS"
+  | "ERROR"
+  | "AXIOS"
+  | "FETCH"
+  | "LOADING";
+
+export type SchemaMode =
+  | Exclude<ApiMode, "LOADING" | "RESPONSE" | "ERROR">
+  | "BASE";
+export type SchemaType = "REQUEST_TYPE" | "RESPONSE_TYPE";
+
+export type RequestState =
+  | { type: "API_RESPONSE"; mode: ApiMode }
+  | {
+      type: "SCHEMA_DEFINITION";
+      schemaType: SchemaType;
+      mode: SchemaMode;
+    };
+
+type RequestAction =
+  | { type: "INITIALIZE" }
+  | { type: "SET_API_MODE"; payload: ApiMode }
+  | {
+      type: "SET_SCHEMA_MODE";
+      payload: SchemaMode;
+      schemaType?: SchemaType;
+    }
+  | {
+      type: "SET_SCHEMA_TYPE";
+      payload: SchemaType;
+      mode?: SchemaMode;
+    };
+
+export const initialState: RequestState = {
+  type: "API_RESPONSE",
+  mode: "RESPONSE",
+};
+
+export const requestReducer = (
+  state: RequestState,
+  action: RequestAction
+): RequestState => {
+  switch (action.type) {
+    case "INITIALIZE":
+      return {
+        ...state,
+        ...initialState,
+      };
+
+    case "SET_API_MODE":
+      return {
+        ...state,
+        type: "API_RESPONSE",
+        mode: action.payload,
+      };
+
+    case "SET_SCHEMA_MODE":
+      if (state.type === "SCHEMA_DEFINITION") {
+        return {
+          ...state,
+          mode: action.payload,
+          ...(action.schemaType && { schemaType: action.schemaType }),
+        };
+      }
+      return {
+        type: "SCHEMA_DEFINITION",
+        schemaType: action.schemaType || "REQUEST_TYPE",
+        mode: action.payload,
+      };
+
+    case "SET_SCHEMA_TYPE":
+      if (state.type === "SCHEMA_DEFINITION") {
+        return {
+          ...state,
+          schemaType: action.payload,
+          ...(action.mode && { mode: action.mode }),
+        };
+      }
+      return {
+        type: "SCHEMA_DEFINITION",
+        schemaType: action.payload,
+        mode: action.mode || "BASE",
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/features/request-api/module/requestReducer.ts
+++ b/src/features/request-api/module/requestReducer.ts
@@ -6,7 +6,8 @@ export type ApiMode =
   | "ERROR"
   | "AXIOS"
   | "FETCH"
-  | "LOADING";
+  | "LOADING"
+  | "ZOD";
 
 export type SchemaMode =
   | Exclude<ApiMode, "LOADING" | "RESPONSE" | "ERROR">

--- a/src/features/request-api/module/requestReducer.ts
+++ b/src/features/request-api/module/requestReducer.ts
@@ -23,6 +23,7 @@ export type RequestState =
 
 type RequestAction =
   | { type: "INITIALIZE" }
+  | { type: "INITIALIZE_TYPE" }
   | { type: "SET_API_MODE"; payload: ApiMode }
   | {
       type: "SET_SCHEMA_MODE";
@@ -50,6 +51,19 @@ export const requestReducer = (
         ...state,
         ...initialState,
       };
+
+    case "INITIALIZE_TYPE": {
+      if (state.type === "API_RESPONSE") {
+        return {
+          ...state,
+          mode: "RESPONSE",
+        };
+      }
+      return {
+        ...state,
+        mode: "BASE",
+      };
+    }
 
     case "SET_API_MODE":
       return {

--- a/src/features/setting/module/hooks/useHandleSetting.ts
+++ b/src/features/setting/module/hooks/useHandleSetting.ts
@@ -1,9 +1,10 @@
 import { useSettingStore } from "@/entities/setting/model/setting-store";
+import { noop } from "@/shared/util/common";
 
 const useHandleSetting = () => {
   const { withReactQuery, toggleReactQuery } = useSettingStore();
 
-  const onSaveSetting = () => {};
+  const onSaveSetting = noop;
 
   return { withReactQuery, toggleReactQuery, onSaveSetting };
 };

--- a/src/pages/content/components/Demo/app.tsx
+++ b/src/pages/content/components/Demo/app.tsx
@@ -1,7 +1,8 @@
+import { noop } from "@/shared/util/common";
 import { useEffect } from "react";
 
 export default function App() {
-  useEffect(() => {}, []);
+  useEffect(noop, []);
 
   return <div className="content-view">content view</div>;
 }

--- a/src/pages/content/modules/getApiList.ts
+++ b/src/pages/content/modules/getApiList.ts
@@ -1,9 +1,144 @@
-import { POST_API_LIST } from "@/entities/docs/model/types/docs";
 import {
+  ApiListType,
+  BrowserSwaggerDocs,
+  Endpoints,
+  Path,
+  POST_API_LIST,
+} from "@/entities/docs/model/types/docs";
+import { SwaggerDocs } from "@/entities/swagger/types";
+import { Method } from "axios";
+
+// FIXME import 부분 오류 수정
+/**
+ * import {
   extractScript,
   extractTagsAndEndpoints,
   fetchSwaggerJson,
 } from "@/features/extract-api/module/utils/extract-api";
+ */
+
+const extractDocsHref = async (): Promise<Path> => {
+  const info = document.querySelector(".info");
+  const href = info.querySelector("a")?.getAttribute("href");
+
+  return { href: href ?? "", host: window.location.origin };
+};
+
+const fetchSwaggerJsonFromUrl = async (
+  url: string
+): Promise<BrowserSwaggerDocs> => {
+  const response = await fetch(url);
+  const data = await response.json();
+  return { data, href: url };
+};
+
+const fetchSwaggerJsonFromScript = async (): Promise<BrowserSwaggerDocs> => {
+  const scripts = Array.from(document.scripts);
+  const swaggerScript = scripts.find((script) =>
+    script.src.includes("swagger-ui-init.js")
+  );
+
+  if (!swaggerScript) return null;
+  const data = await fetch(swaggerScript.src)
+    .then((response) => response.text())
+    .then((scriptContent) => {
+      const optionsRegex =
+        /let options = ({.*?});\s*url = options.swaggerUrl/gms;
+      const match = optionsRegex.exec(scriptContent);
+
+      if (match && match[1]) {
+        const options = JSON.parse(match[1]);
+
+        const swaggerDoc = options.swaggerDoc;
+        if (typeof swaggerDoc === "string") {
+          return fetchSwaggerJsonFromUrl(swaggerDoc);
+        } else if (swaggerDoc && typeof swaggerDoc === "object") {
+          return swaggerDoc;
+        } else {
+          return null;
+        }
+      } else {
+        return null;
+      }
+    });
+
+  return { data, href: "" };
+};
+
+export const fetchSwaggerJson = async (): Promise<BrowserSwaggerDocs> => {
+  const swaggerJsonFromScript = await fetchSwaggerJsonFromScript();
+  if (swaggerJsonFromScript) {
+    return swaggerJsonFromScript;
+  }
+
+  const path = await extractDocsHref();
+
+  if (path.href) {
+    const swaggerJsonFromUrl = await fetchSwaggerJsonFromUrl(path.href);
+    return swaggerJsonFromUrl;
+  }
+
+  const swaggerJsonFromUrl = await fetchSwaggerJsonFromUrl("/swagger.json");
+  if (swaggerJsonFromUrl) {
+    return swaggerJsonFromUrl;
+  }
+
+  throw new Error("Unable to fetch Swagger JSON");
+};
+
+export const extractTagsAndEndpoints = (
+  swaggerJson: SwaggerDocs
+): ApiListType => {
+  const tags: string[] = [];
+  const endpoints: Endpoints = {};
+
+  Object.keys(swaggerJson.paths).forEach((path) => {
+    Object.keys(swaggerJson.paths[path]).forEach((method) => {
+      const tag = swaggerJson.paths[path][method]?.tags?.[0];
+      if (!tags.includes(tag)) {
+        tags.push(tag);
+      }
+      if (!endpoints[tag]) {
+        endpoints[tag] = [];
+      }
+      endpoints[tag].push({
+        method: method as Method,
+        path,
+        description:
+          swaggerJson.paths[path][method].description ??
+          swaggerJson.paths[path][method].summary,
+        summary:
+          swaggerJson.paths[path][method].summary ??
+          swaggerJson.paths[path][method].description,
+      });
+    });
+  });
+
+  return { tags, endpoints };
+};
+
+export const extractScript = async (): Promise<string> => {
+  const scripts = Array.from(document.scripts);
+  const swaggerScript = scripts.find((script) =>
+    script.src.includes("swagger-ui-init.js")
+  );
+
+  if (!swaggerScript) return "";
+  return await fetch(swaggerScript.src)
+    .then((response) => response.text())
+    .then((scriptContent) => {
+      const optionsRegex =
+        /let options = ({.*?});\s*url = options.swaggerUrl/gms;
+      const match = optionsRegex.exec(scriptContent);
+
+      if (match && match[1]) {
+        const options = JSON.parse(match[1]);
+        return options.swaggerDoc;
+      } else {
+        return "";
+      }
+    });
+};
 
 const handleGetApiList = async () => {
   try {

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -17,7 +17,6 @@ import { Flip, ToastContainer } from "react-toastify";
 import { apiListStyle } from "../ApiListPage/ui/apiList.css";
 import { requestStyles } from "./request.css";
 
-import { SchemaInfo } from "@/entities/swagger/types";
 import {
   ApiMode,
   initialState,
@@ -26,6 +25,7 @@ import {
   SchemaMode,
 } from "@/features/request-api/module/requestReducer";
 import { noop } from "@/shared/util/common";
+import { openApiToJson } from "@/shared/util/typeGenerator";
 import "react-toastify/dist/ReactToastify.css";
 
 export type Mode =
@@ -62,41 +62,6 @@ export const RequestPage = () => {
     []
   );
 
-  const getJSONSchema = (typeSchema: SchemaInfo) => {
-    if (!typeSchema) {
-      return "No type available for this API";
-    }
-
-    const { properties, required } = typeSchema;
-    const jsonData: Record<string, any> = {};
-
-    Object.entries(properties).forEach(([key, value]) => {
-      const isRequired = required.includes(key);
-      const type = getTypeScriptType(value);
-      jsonData[isRequired ? key : `${key}?`] = type;
-    });
-
-    return jsonData;
-  };
-
-  const getTypeScriptType = (property: unknown): string => {
-    if (typeof property === "object" && property !== null) {
-      const prop = property as any;
-      if (prop.type === "string") {
-        if (prop.format === "date-time") return "string";
-        return "string";
-      }
-      if (prop.type === "integer" || prop.type === "number") return "number";
-      if (prop.type === "boolean") return "boolean";
-      if (prop.type === "array") {
-        const itemType = getTypeScriptType(prop.items);
-        return `${itemType}[]`;
-      }
-      if (prop.type === "object") return "object";
-    }
-    return "unknown";
-  };
-
   const handleMode = (mode: Mode) => {
     if (state.type === "API_RESPONSE") {
       dispatch({ type: "SET_API_MODE", payload: mode as ApiMode });
@@ -118,11 +83,13 @@ export const RequestPage = () => {
     if (state.type === "API_RESPONSE") return response;
 
     if (state.schemaType === "REQUEST_TYPE") {
-      return getJSONSchema(api.typeInfo?.requestType);
+      const Json = openApiToJson(api.typeInfo?.requestType);
+      return Json ?? "Request type is not defined for this API";
     }
 
     if (state.schemaType === "RESPONSE_TYPE") {
-      return getJSONSchema(api.typeInfo?.responseType);
+      const Json = openApiToJson(api.typeInfo?.responseType);
+      return Json ?? "Response type is not defined for this API";
     }
   }, [state, api.typeInfo]);
 
@@ -173,7 +140,6 @@ export const RequestPage = () => {
           </div>
           <div className={requestStyles.fixedButtonWrapper}>
             <Modal>
-              {/* 트리거 분리 해야함;; */}
               <Modal.Trigger
                 as={
                   <div

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -17,6 +17,7 @@ import { Flip, ToastContainer } from "react-toastify";
 import { apiListStyle } from "../ApiListPage/ui/apiList.css";
 import { requestStyles } from "./request.css";
 
+import { noop } from "@/shared/util/common";
 import "react-toastify/dist/ReactToastify.css";
 
 export type Mode =
@@ -103,8 +104,7 @@ export const RequestPage = () => {
             <Modal>
               <Modal.Trigger
                 as={
-                  // eslint-disable-next-line @typescript-eslint/no-empty-function
-                  <Button onClick={() => {}} type="submit">
+                  <Button onClick={noop} type="submit">
                     SUBMIT
                   </Button>
                 }

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -58,7 +58,7 @@ export const RequestPage = () => {
   };
   // 3. modal 상태 초기화
   const initializeMode = useCallback(
-    () => dispatch({ type: "INITIALIZE" }),
+    () => dispatch({ type: "INITIALIZE_TYPE" }),
     []
   );
 
@@ -108,7 +108,13 @@ export const RequestPage = () => {
     <div className={apiListStyle.app}>
       <Header showBackButton />
       <div className={requestStyles.requestWrapper}>
-        <form className={requestStyles.body} onSubmit={handleSubmit}>
+        <form
+          className={requestStyles.body}
+          onSubmit={(e) => {
+            dispatch({ type: "SET_API_MODE", payload: "RESPONSE" });
+            handleSubmit(e);
+          }}
+        >
           <div className={requestStyles.apiItemContainer}>
             <APIItem api={api} />
           </div>
@@ -140,14 +146,11 @@ export const RequestPage = () => {
           </div>
           <div className={requestStyles.fixedButtonWrapper}>
             <Modal>
-              <Modal.Trigger
-                as={
-                  <div
-                    onClick={noop}
-                    className={requestStyles.modalTriggerContainer}
-                  >
-                    <div className={requestStyles.typeExtractionContainer}>
-                      <div className={requestStyles.typeExtractionButtons}>
+              <div className={requestStyles.modalTriggerContainer}>
+                <div className={requestStyles.typeExtractionContainer}>
+                  <div className={requestStyles.typeExtractionButtons}>
+                    <Modal.Trigger
+                      as={
                         <Button
                           type="button"
                           color="blue"
@@ -161,7 +164,10 @@ export const RequestPage = () => {
                         >
                           Extract Request
                         </Button>
-
+                      }
+                    />
+                    <Modal.Trigger
+                      as={
                         <Button
                           type="button"
                           color="green"
@@ -175,19 +181,18 @@ export const RequestPage = () => {
                         >
                           Extract Response
                         </Button>
-                      </div>
-                    </div>
-                    <Button
-                      onClick={() =>
-                        dispatch({ type: "SET_API_MODE", payload: "RESPONSE" })
                       }
-                      type="submit"
-                    >
+                    />
+                  </div>
+                </div>
+                <Modal.Trigger
+                  as={
+                    <Button type="submit" onClick={noop}>
                       SUBMIT
                     </Button>
-                  </div>
-                }
-              />
+                  }
+                />
+              </div>
               <Modal.Content>
                 {state.mode === "LOADING" && <Loading />}
                 {state.type === "API_RESPONSE" && state.mode === "RESPONSE" && (

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -17,6 +17,7 @@ import { Flip, ToastContainer } from "react-toastify";
 import { apiListStyle } from "../ApiListPage/ui/apiList.css";
 import { requestStyles } from "./request.css";
 
+import { SchemaInfo } from "@/entities/swagger/types";
 import { noop } from "@/shared/util/common";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -29,24 +30,64 @@ export type Mode =
   | "LOADING"
   | "ZOD";
 
+type SchemaMode = "REQUEST_TYPE" | "RESPONSE_TYPE";
+
 export const RequestPage = () => {
   // FIRST RENDER
   const api = useLocation().state as APIWithParamsAndBodyAndHost;
 
   const { params, body } = api;
+  const typeInfo = (api as any).typeInfo || (api as any).detailSchema;
 
   // INTERACTION
   // 1. mode 상태 관리
   const [mode, setMode] = useState<Mode>("RESPONSE");
+  const [schemaMode, setSchemaMode] = useState<SchemaMode | null>(null);
   // 2. modal 닫기
   const onCloseModal = () => {
     // modal 애니메이션 끝나고 mode 변경
     setTimeout(() => {
       setMode("RESPONSE");
+      setSchemaMode(null);
     }, 500);
   };
   // 3. modal 상태 초기화
   const initializeMode = useCallback(() => setMode("RESPONSE"), []);
+
+  const getJSONSchema = (typeSchema: SchemaInfo) => {
+    if (!typeSchema) {
+      return "No type available for this API";
+    }
+
+    const { properties, required } = typeSchema;
+    const jsonData: Record<string, any> = {};
+
+    Object.entries(properties).forEach(([key, value]) => {
+      const isRequired = required.includes(key);
+      const type = getTypeScriptType(value);
+      jsonData[isRequired ? key : `${key}?`] = type;
+    });
+
+    return jsonData;
+  };
+
+  const getTypeScriptType = (property: unknown): string => {
+    if (typeof property === "object" && property !== null) {
+      const prop = property as any;
+      if (prop.type === "string") {
+        if (prop.format === "date-time") return "string";
+        return "string";
+      }
+      if (prop.type === "integer" || prop.type === "number") return "number";
+      if (prop.type === "boolean") return "boolean";
+      if (prop.type === "array") {
+        const itemType = getTypeScriptType(prop.items);
+        return `${itemType}[]`;
+      }
+      if (prop.type === "object") return "object";
+    }
+    return "unknown";
+  };
 
   // 2. Request 비지니스 로직
   const { response, formValues, handleChange, handleSubmit, handleArray } =
@@ -54,6 +95,17 @@ export const RequestPage = () => {
       api,
       setMode,
     });
+
+  const currentCode = (() => {
+    if (schemaMode === "REQUEST_TYPE") {
+      return getJSONSchema(typeInfo?.requestType);
+    }
+
+    if (schemaMode === "RESPONSE_TYPE") {
+      return getJSONSchema(typeInfo?.responseType);
+    }
+    return response;
+  })();
 
   // 3. Code 비지니스 로직
   const {
@@ -64,7 +116,7 @@ export const RequestPage = () => {
     onClickFetch,
     onClickTS,
     onClickZod,
-  } = useHandleCode({ api, response, setMode });
+  } = useHandleCode({ api, response: currentCode, setMode });
 
   return (
     <div className={apiListStyle.app}>
@@ -104,14 +156,38 @@ export const RequestPage = () => {
             <Modal>
               <Modal.Trigger
                 as={
-                  <Button onClick={noop} type="submit">
-                    SUBMIT
-                  </Button>
+                  <div onClick={noop}>
+                    <div className={requestStyles.typeExtractionContainer}>
+                      <div className={requestStyles.typeExtractionButtons}>
+                        <Button
+                          type="button"
+                          color="typeExtraction"
+                          onClick={() => {
+                            setSchemaMode("REQUEST_TYPE");
+                          }}
+                        >
+                          📝 Request Type
+                        </Button>
+                        <Button
+                          type="button"
+                          color="typeExtraction"
+                          onClick={() => {
+                            setSchemaMode("RESPONSE_TYPE");
+                          }}
+                        >
+                          📄 Response Type
+                        </Button>
+                      </div>
+                    </div>
+                    <Button onClick={() => setSchemaMode(null)} type="submit">
+                      SUBMIT
+                    </Button>
+                  </div>
                 }
               />
               <Modal.Content>
                 {mode === "LOADING" && <Loading />}
-                {response && mode === "RESPONSE" && (
+                {schemaMode === null && response && mode === "RESPONSE" && (
                   <ModalCodeBlock
                     description="Response"
                     code={JSON.stringify(response, null, 2)}
@@ -123,6 +199,19 @@ export const RequestPage = () => {
                     onClickAxios={onClickAxios}
                     onClickFetch={onClickFetch}
                     onClickZod={onClickZod}
+                  />
+                )}
+                {schemaMode !== null && mode === "RESPONSE" && (
+                  <ModalCodeBlock
+                    description={schemaMode}
+                    code={JSON.stringify(currentCode, null, 2)}
+                    mode="RESPONSE"
+                    ref={codeRef}
+                    onClose={onCloseModal}
+                    onClickCopy={copyToClipboard}
+                    onClickTS={onClickTS}
+                    onClickAxios={onClickAxios}
+                    onClickFetch={onClickFetch}
                   />
                 )}
                 {mode === "TS" && (

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -27,17 +27,6 @@ import { noop } from "@/shared/util/common";
 import { openApiToLiteralJson } from "@/shared/util/typeGenerator";
 import "react-toastify/dist/ReactToastify.css";
 
-export type Mode =
-  | "RESPONSE"
-  | "TS"
-  | "ERROR"
-  | "AXIOS"
-  | "FETCH"
-  | "LOADING"
-  | "ZOD";
-
-type SchemaMode = "REQUEST_TYPE" | "RESPONSE_TYPE";
-
 export const RequestPage = () => {
   // FIRST RENDER
   const api = useLocation().state as APIWithParamsAndBodyAndHost;
@@ -220,6 +209,7 @@ export const RequestPage = () => {
                       onClickTS={onClickTS}
                       onClickAxios={onClickAxios}
                       onClickFetch={onClickFetch}
+                      onClickZod={onClickZod}
                     />
                   )}
                 {state.mode === "TS" && (
@@ -265,7 +255,7 @@ export const RequestPage = () => {
                     onClickCopy={copyToClipboard}
                   />
                 )}
-                {mode === "ZOD" && (
+                {state.mode === "ZOD" && (
                   <ModalCodeBlock
                     description="ZOD"
                     descriptionColor="purple"

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -10,7 +10,7 @@ import useHandleCode from "@/widgets/code-block/module/hooks/useHandleCode";
 import ModalCodeBlock from "@/widgets/code-block/ui/code-block-modal/CodeBlockView";
 import { RequestBody } from "@/widgets/request-body/ui/api-body/RequestBody";
 import { RequestParam } from "@/widgets/request-param/ui/api-param/RequestParam";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useReducer } from "react";
 import { VscBracketError as ErrorIcon } from "react-icons/vsc";
 import { useLocation } from "react-router-dom";
 import { Flip, ToastContainer } from "react-toastify";
@@ -18,6 +18,13 @@ import { apiListStyle } from "../ApiListPage/ui/apiList.css";
 import { requestStyles } from "./request.css";
 
 import { SchemaInfo } from "@/entities/swagger/types";
+import {
+  ApiMode,
+  initialState,
+  Mode,
+  requestReducer,
+  SchemaMode,
+} from "@/features/request-api/module/requestReducer";
 import { noop } from "@/shared/util/common";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -37,22 +44,23 @@ export const RequestPage = () => {
   const api = useLocation().state as APIWithParamsAndBodyAndHost;
 
   const { params, body } = api;
-  const typeInfo = (api as any).typeInfo || (api as any).detailSchema;
 
   // INTERACTION
   // 1. mode 상태 관리
-  const [mode, setMode] = useState<Mode>("RESPONSE");
-  const [schemaMode, setSchemaMode] = useState<SchemaMode | null>(null);
+  const [state, dispatch] = useReducer(requestReducer, initialState);
+
   // 2. modal 닫기
   const onCloseModal = () => {
     // modal 애니메이션 끝나고 mode 변경
     setTimeout(() => {
-      setMode("RESPONSE");
-      setSchemaMode(null);
+      dispatch({ type: "INITIALIZE" });
     }, 500);
   };
   // 3. modal 상태 초기화
-  const initializeMode = useCallback(() => setMode("RESPONSE"), []);
+  const initializeMode = useCallback(
+    () => dispatch({ type: "INITIALIZE" }),
+    []
+  );
 
   const getJSONSchema = (typeSchema: SchemaInfo) => {
     if (!typeSchema) {
@@ -89,23 +97,34 @@ export const RequestPage = () => {
     return "unknown";
   };
 
+  const handleMode = (mode: Mode) => {
+    if (state.type === "API_RESPONSE") {
+      dispatch({ type: "SET_API_MODE", payload: mode as ApiMode });
+      return;
+    }
+
+    dispatch({ type: "SET_SCHEMA_MODE", payload: mode as SchemaMode });
+  };
+
   // 2. Request 비지니스 로직
   const { response, formValues, handleChange, handleSubmit, handleArray } =
     useHandleRequest({
       api,
-      setMode,
+      setMode: handleMode,
     });
 
-  const currentCode = (() => {
-    if (schemaMode === "REQUEST_TYPE") {
-      return getJSONSchema(typeInfo?.requestType);
+  // 상태에 따라 code비즈니스 로직에 해당하는 코드 반환
+  const baseCode = useMemo(() => {
+    if (state.type === "API_RESPONSE") return response;
+
+    if (state.schemaType === "REQUEST_TYPE") {
+      return getJSONSchema(api.typeInfo?.requestType);
     }
 
-    if (schemaMode === "RESPONSE_TYPE") {
-      return getJSONSchema(typeInfo?.responseType);
+    if (state.schemaType === "RESPONSE_TYPE") {
+      return getJSONSchema(api.typeInfo?.responseType);
     }
-    return response;
-  })();
+  }, [state, api.typeInfo]);
 
   // 3. Code 비지니스 로직
   const {
@@ -116,7 +135,7 @@ export const RequestPage = () => {
     onClickFetch,
     onClickTS,
     onClickZod,
-  } = useHandleCode({ api, response: currentCode, setMode });
+  } = useHandleCode({ api, response: baseCode, setMode: handleMode });
 
   return (
     <div className={apiListStyle.app}>
@@ -154,6 +173,7 @@ export const RequestPage = () => {
           </div>
           <div className={requestStyles.fixedButtonWrapper}>
             <Modal>
+              {/* 트리거 분리 해야함;; */}
               <Modal.Trigger
                 as={
                   <div
@@ -167,7 +187,10 @@ export const RequestPage = () => {
                           color="blue"
                           style={{ flex: 1 }}
                           onClick={() => {
-                            setSchemaMode("REQUEST_TYPE");
+                            dispatch({
+                              type: "SET_SCHEMA_TYPE",
+                              payload: "REQUEST_TYPE",
+                            });
                           }}
                         >
                           Extract Request
@@ -178,26 +201,34 @@ export const RequestPage = () => {
                           color="green"
                           style={{ flex: 1 }}
                           onClick={() => {
-                            setSchemaMode("RESPONSE_TYPE");
+                            dispatch({
+                              type: "SET_SCHEMA_TYPE",
+                              payload: "RESPONSE_TYPE",
+                            });
                           }}
                         >
                           Extract Response
                         </Button>
                       </div>
                     </div>
-                    <Button onClick={() => setSchemaMode(null)} type="submit">
+                    <Button
+                      onClick={() =>
+                        dispatch({ type: "SET_API_MODE", payload: "RESPONSE" })
+                      }
+                      type="submit"
+                    >
                       SUBMIT
                     </Button>
                   </div>
                 }
               />
               <Modal.Content>
-                {mode === "LOADING" && <Loading />}
-                {schemaMode === null && response && mode === "RESPONSE" && (
+                {state.mode === "LOADING" && <Loading />}
+                {state.type === "API_RESPONSE" && state.mode === "RESPONSE" && (
                   <ModalCodeBlock
                     description="Response"
                     code={JSON.stringify(response, null, 2)}
-                    mode="RESPONSE"
+                    mode="base"
                     ref={codeRef}
                     onClose={onCloseModal}
                     onClickCopy={copyToClipboard}
@@ -207,20 +238,21 @@ export const RequestPage = () => {
                     onClickZod={onClickZod}
                   />
                 )}
-                {schemaMode !== null && mode === "RESPONSE" && (
-                  <ModalCodeBlock
-                    description={schemaMode}
-                    code={JSON.stringify(currentCode, null, 2)}
-                    mode="RESPONSE"
-                    ref={codeRef}
-                    onClose={onCloseModal}
-                    onClickCopy={copyToClipboard}
-                    onClickTS={onClickTS}
-                    onClickAxios={onClickAxios}
-                    onClickFetch={onClickFetch}
-                  />
-                )}
-                {mode === "TS" && (
+                {state.type === "SCHEMA_DEFINITION" &&
+                  state.mode === "BASE" && (
+                    <ModalCodeBlock
+                      description={state.schemaType}
+                      code={JSON.stringify(baseCode, null, 2)}
+                      mode="base"
+                      ref={codeRef}
+                      onClose={onCloseModal}
+                      onClickCopy={copyToClipboard}
+                      onClickTS={onClickTS}
+                      onClickAxios={onClickAxios}
+                      onClickFetch={onClickFetch}
+                    />
+                  )}
+                {state.mode === "TS" && (
                   <ModalCodeBlock
                     description="Type"
                     code={code}
@@ -230,7 +262,7 @@ export const RequestPage = () => {
                     onClickCopy={copyToClipboard}
                   />
                 )}
-                {mode === "ERROR" && (
+                {state.mode === "ERROR" && (
                   <ModalCodeBlock
                     description="Error"
                     descriptionColor="red"
@@ -241,7 +273,7 @@ export const RequestPage = () => {
                     onClickCopy={copyToClipboard}
                   />
                 )}
-                {mode === "AXIOS" && (
+                {state.mode === "AXIOS" && (
                   <ModalCodeBlock
                     description="AXIOS"
                     descriptionColor="red"
@@ -252,7 +284,7 @@ export const RequestPage = () => {
                     onClickCopy={copyToClipboard}
                   />
                 )}
-                {mode === "FETCH" && (
+                {state.mode === "FETCH" && (
                   <ModalCodeBlock
                     description="FETCH"
                     descriptionColor="orange"

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -83,15 +83,15 @@ export const RequestPage = () => {
     if (state.type === "API_RESPONSE") return response;
 
     if (state.schemaType === "REQUEST_TYPE") {
-      const Json = openApiToJson(api.typeInfo?.requestType);
+      const Json = openApiToJson(api.detailSchema?.requestType);
       return Json ?? "Request type is not defined for this API";
     }
 
     if (state.schemaType === "RESPONSE_TYPE") {
-      const Json = openApiToJson(api.typeInfo?.responseType);
+      const Json = openApiToJson(api.detailSchema?.responseType);
       return Json ?? "Response type is not defined for this API";
     }
-  }, [state, api.typeInfo]);
+  }, [state, api.detailSchema]);
 
   // 3. Code 비지니스 로직
   const {

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -20,7 +20,6 @@ import { requestStyles } from "./request.css";
 import {
   ApiMode,
   initialState,
-  Mode,
   requestReducer,
   SchemaMode,
 } from "@/features/request-api/module/requestReducer";
@@ -62,7 +61,7 @@ export const RequestPage = () => {
     []
   );
 
-  const handleMode = (mode: Mode) => {
+  const handleMode = (mode: "RESPONSE" | "ERROR" | "LOADING") => {
     if (state.type === "API_RESPONSE") {
       dispatch({ type: "SET_API_MODE", payload: mode as ApiMode });
       return;

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -156,26 +156,32 @@ export const RequestPage = () => {
             <Modal>
               <Modal.Trigger
                 as={
-                  <div onClick={noop}>
+                  <div
+                    onClick={noop}
+                    className={requestStyles.modalTriggerContainer}
+                  >
                     <div className={requestStyles.typeExtractionContainer}>
                       <div className={requestStyles.typeExtractionButtons}>
                         <Button
                           type="button"
-                          color="typeExtraction"
+                          color="blue"
+                          style={{ flex: 1 }}
                           onClick={() => {
                             setSchemaMode("REQUEST_TYPE");
                           }}
                         >
-                          📝 Request Type
+                          Extract Request
                         </Button>
+
                         <Button
                           type="button"
-                          color="typeExtraction"
+                          color="green"
+                          style={{ flex: 1 }}
                           onClick={() => {
                             setSchemaMode("RESPONSE_TYPE");
                           }}
                         >
-                          📄 Response Type
+                          Extract Response
                         </Button>
                       </div>
                     </div>

--- a/src/pages/popup/pages/RequestPage/RequestPage.tsx
+++ b/src/pages/popup/pages/RequestPage/RequestPage.tsx
@@ -24,7 +24,7 @@ import {
   SchemaMode,
 } from "@/features/request-api/module/requestReducer";
 import { noop } from "@/shared/util/common";
-import { openApiToJson } from "@/shared/util/typeGenerator";
+import { openApiToLiteralJson } from "@/shared/util/typeGenerator";
 import "react-toastify/dist/ReactToastify.css";
 
 export type Mode =
@@ -82,12 +82,12 @@ export const RequestPage = () => {
     if (state.type === "API_RESPONSE") return response;
 
     if (state.schemaType === "REQUEST_TYPE") {
-      const Json = openApiToJson(api.detailSchema?.requestType);
+      const Json = openApiToLiteralJson(api.detailSchema?.requestType);
       return Json ?? "Request type is not defined for this API";
     }
 
     if (state.schemaType === "RESPONSE_TYPE") {
-      const Json = openApiToJson(api.detailSchema?.responseType);
+      const Json = openApiToLiteralJson(api.detailSchema?.responseType);
       return Json ?? "Response type is not defined for this API";
     }
   }, [state, api.detailSchema]);

--- a/src/pages/popup/pages/RequestPage/request.css.ts
+++ b/src/pages/popup/pages/RequestPage/request.css.ts
@@ -26,6 +26,27 @@ export const requestStyles = {
     width: "100%",
   }),
 
+  typeExtractionContainer: style({
+    display: "flex",
+    width: "100%",
+    padding: "15px 0",
+    borderBottom: `1px solid ${vars.color.scrollbar}`,
+    backgroundColor: vars.color.darkGrey,
+  }),
+
+  typeExtractionButtons: style({
+    display: "flex",
+    gap: "12px",
+    width: "100%",
+    justifyContent: "center",
+  }),
+
+  modalTriggerContainer: style({
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+  }),
+
   requestBlock: style({
     overflowY: "auto",
     maxHeight: "70%",

--- a/src/shared/ui/Dropdown.tsx
+++ b/src/shared/ui/Dropdown.tsx
@@ -11,12 +11,13 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { noop } from "../util/common";
 import { dropDownStyles } from "./styles/dropdown.css";
 
 const DropdownContext = React.createContext<{
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}>({ isOpen: false, setIsOpen: () => {} });
+}>({ isOpen: false, setIsOpen: noop });
 
 const Dropdown = ({ children }: { children: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+import { noop } from "@/shared/util/common";
 import CodeBlock from "@/widgets/code-block/ui/code-block/CodeBlock";
 import classNames from "classnames";
 import {
@@ -28,7 +29,7 @@ const ModalContext = createContext<{
   onClose?: () => void;
 }>({
   modalOpen: false,
-  setModalOpen: () => {},
+  setModalOpen: noop,
 });
 
 interface ModalProps {

--- a/src/shared/util/common.ts
+++ b/src/shared/util/common.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+export { noop };

--- a/src/shared/util/typeGenerator.test.ts
+++ b/src/shared/util/typeGenerator.test.ts
@@ -1,6 +1,9 @@
-import { jsonToTs, jsonToZod, toTsType openApiToLiteralJson } from "./typeGenerator";
-import { jsonToTs, jsonToZod, toTsType, openApiToLiteralJson } from "./typeGenerator";
-
+import {
+  jsonToTs,
+  jsonToZod,
+  openApiToLiteralJson,
+  toTsType,
+} from "./typeGenerator";
 
 describe("toTsType", () => {
   it('타입이 숫자인 경우 "number"를 반환한다', () => {

--- a/src/shared/util/typeGenerator.test.ts
+++ b/src/shared/util/typeGenerator.test.ts
@@ -1,4 +1,6 @@
-import { jsonToTs, jsonToZod, toTsType } from "./typeGenerator";
+import { jsonToTs, jsonToZod, toTsType openApiToLiteralJson } from "./typeGenerator";
+import { jsonToTs, jsonToZod, toTsType, openApiToLiteralJson } from "./typeGenerator";
+
 
 describe("toTsType", () => {
   it('타입이 숫자인 경우 "number"를 반환한다', () => {
@@ -296,5 +298,311 @@ describe("jsonToZod", () => {
       "});";
 
     expect(jsonToZod(json)).toEqual(expected);
+  });
+});
+
+describe("openApiToLiteralJson", () => {
+  it("기본 타입들에 대해 매핑되는 리터럴 값을 생성한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "TestSchema",
+      properties: {
+        id: {
+          type: "integer",
+          format: "int32",
+          description: "게시글 ID",
+        },
+        title: {
+          type: "string",
+          description: "게시글 제목",
+        },
+        isActive: {
+          type: "boolean",
+          description: "활성화 여부",
+        },
+        content: {
+          type: "string",
+        },
+      },
+      required: ["id", "title", "isActive"],
+      type: "object",
+    };
+
+    const expected = {
+      id: 0,
+      title: "string",
+      isActive: true,
+      "content?": "string",
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("필수 필드와 선택 필드를 올바르게 구분한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "RequiredOptionalSchema",
+      properties: {
+        requiredField: {
+          type: "string",
+        },
+        optionalField: {
+          type: "number",
+        },
+      },
+      required: ["requiredField"],
+      type: "object",
+    };
+
+    const expected = {
+      requiredField: "string",
+      "optionalField?": 0,
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("중첩된 객체 구조를 올바르게 처리한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "NestedObjectSchema",
+      properties: {
+        user: {
+          type: "object",
+          properties: {
+            id: {
+              type: "integer",
+              format: "int32",
+            },
+            profile: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
+                age: {
+                  type: "integer",
+                },
+              },
+              required: ["name", "age"],
+            },
+          },
+          required: ["id", "profile"],
+        },
+      },
+      required: ["user"],
+      type: "object",
+    };
+
+    const expected = {
+      user: {
+        id: 0,
+        profile: {
+          name: "string",
+          age: 0,
+        },
+      },
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("배열 타입을 올바르게 처리한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "ArraySchema",
+      properties: {
+        tags: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+        scores: {
+          type: "array",
+          items: {
+            type: "integer",
+            format: "int32",
+          },
+        },
+        users: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "integer",
+              },
+              name: {
+                type: "string",
+              },
+            },
+            required: ["id", "name"],
+          },
+        },
+      },
+      required: ["tags", "scores", "users"],
+      type: "object",
+    };
+
+    const expected = {
+      tags: ["string"],
+      scores: [0],
+      users: [
+        {
+          id: 0,
+          name: "string",
+        },
+      ],
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("특수 포맷의 문자열을 올바르게 처리한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "FormatStringSchema",
+      properties: {
+        createdAt: {
+          type: "string",
+          format: "date-time",
+        },
+        birthDate: {
+          type: "string",
+          format: "date",
+        },
+        password: {
+          type: "string",
+          format: "password",
+        },
+        fileData: {
+          type: "string",
+          format: "binary",
+        },
+      },
+      required: ["createdAt", "birthDate", "password", "fileData"],
+      type: "object",
+    };
+
+    const expected = {
+      createdAt: "date_time_string",
+      birthDate: "date_string",
+      password: "password_string",
+      fileData: "base64_string",
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("null 스키마에 대해 null을 반환한다", () => {
+    expect(openApiToLiteralJson(null)).toBeNull();
+  });
+
+  it("빈 properties에 대해 빈 객체를 반환한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "EmptySchema",
+      properties: {},
+      required: [],
+      type: "object",
+    };
+
+    const expected = {};
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
+  });
+
+  it("복잡한 중첩 구조를 올바르게 처리한다", () => {
+    const schema = {
+      schema: "inline",
+      typeName: "ComplexNestedSchema",
+      properties: {
+        posts: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "integer",
+              },
+              title: {
+                type: "string",
+              },
+              author: {
+                type: "object",
+                properties: {
+                  id: {
+                    type: "integer",
+                  },
+                  name: {
+                    type: "string",
+                  },
+                  profile: {
+                    type: "object",
+                    properties: {
+                      avatar: {
+                        type: "string",
+                        format: "binary",
+                      },
+                      bio: {
+                        type: "string",
+                      },
+                    },
+                    required: ["avatar"],
+                  },
+                },
+                required: ["id", "name", "profile"],
+              },
+              tags: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+            },
+            required: ["id", "title", "author", "tags"],
+          },
+        },
+        metadata: {
+          type: "object",
+          properties: {
+            total: {
+              type: "integer",
+            },
+            page: {
+              type: "integer",
+            },
+          },
+          required: ["total", "page"],
+        },
+      },
+      required: ["posts", "metadata"],
+      type: "object",
+    };
+
+    const expected = {
+      posts: [
+        {
+          id: 0,
+          title: "string",
+          author: {
+            id: 0,
+            name: "string",
+            profile: {
+              avatar: "base64_string",
+              "bio?": "string",
+            },
+          },
+          tags: ["string"],
+        },
+      ],
+      metadata: {
+        total: 0,
+        page: 0,
+      },
+    };
+
+    expect(openApiToLiteralJson(schema)).toEqual(expected);
   });
 });

--- a/src/shared/util/typeGenerator.ts
+++ b/src/shared/util/typeGenerator.ts
@@ -128,7 +128,7 @@ export const jsonToTs = (
   return { interfaceArray: interfaces, rootInterfaceKey };
 };
 
-export const openApiToJson = (schema: SchemaInfo | null) => {
+export const openApiToLiteralJson = (schema: SchemaInfo | null) => {
   if (!schema) {
     return null;
   }
@@ -138,28 +138,59 @@ export const openApiToJson = (schema: SchemaInfo | null) => {
 
   Object.entries(properties).forEach(([key, value]) => {
     const isRequired = required.includes(key);
-    const type = getTypeScriptType(value);
-    jsonData[isRequired ? key : `${key}?`] = type;
+    const literalValue = getLiteralValue(value, required);
+    jsonData[isRequired ? key : `${key}?`] = literalValue;
   });
 
   return jsonData;
 };
 
-const getTypeScriptType = (property: unknown): string => {
+const getLiteralValue = (
+  property: unknown,
+  parentRequired: string[] = []
+): unknown => {
   if (typeof property === "object" && property !== null) {
     const prop = property as FormSchemaProperty;
+
+    if (prop.properties) {
+      const nestedObject: Record<string, unknown> = {};
+      const nestedRequired = prop.required || [];
+
+      Object.entries(prop.properties).forEach(([key, value]) => {
+        const isRequired = nestedRequired.includes(key);
+        const literalValue = getLiteralValue(value, nestedRequired);
+        nestedObject[isRequired ? key : `${key}?`] = literalValue;
+      });
+      return nestedObject;
+    }
+
     if (prop.type === "string") {
-      if (prop.format === "date-time") return "string";
+      if (prop.format === "date-time") return "date_time_string";
+      if (prop.format === "date") return "date_string";
+      if (prop.format === "password") return "password_string";
+      if (prop.format === "byte" || prop.format === "binary")
+        return "base64_string";
       return "string";
     }
-    if (prop.type === "integer" || prop.type === "number") return "number";
-    if (prop.type === "boolean") return "boolean";
-    if (prop.type === "array") {
-      const itemType = getTypeScriptType(prop.items);
-      return `${itemType}[]`;
+
+    if (prop.type === "integer" || prop.type === "number") {
+      return 0;
     }
-    if (prop.type === "object") return "object";
+
+    if (prop.type === "boolean") {
+      return true;
+    }
+
+    if (prop.type === "array") {
+      const itemValue = getLiteralValue(prop.items, parentRequired);
+      return [itemValue];
+    }
+
+    if (prop.type === "object") {
+      return {};
+    }
   }
+
   return "unknown";
 };
 

--- a/src/shared/util/typeGenerator.ts
+++ b/src/shared/util/typeGenerator.ts
@@ -1,9 +1,11 @@
 import { EMPTY_RESPONSE } from "@/entities/api/config/status";
 import {
+  SchemaInfo,
   SchemasProperties,
   SwaggerFormat,
   SwaggerType,
 } from "@/entities/swagger/types";
+import { FormSchemaProperty } from "@/features/api-generate/module/hooks/useApiAddForm";
 
 export const isArrayType = (value: any): boolean =>
   typeof value === "string" && value.startsWith("[") && value.endsWith("]");
@@ -124,6 +126,41 @@ export const jsonToTs = (
   }
 
   return { interfaceArray: interfaces, rootInterfaceKey };
+};
+
+export const openApiToJson = (schema: SchemaInfo | null) => {
+  if (!schema) {
+    return null;
+  }
+
+  const { properties, required } = schema;
+  const jsonData: Record<string, unknown> = {};
+
+  Object.entries(properties).forEach(([key, value]) => {
+    const isRequired = required.includes(key);
+    const type = getTypeScriptType(value);
+    jsonData[isRequired ? key : `${key}?`] = type;
+  });
+
+  return jsonData;
+};
+
+const getTypeScriptType = (property: unknown): string => {
+  if (typeof property === "object" && property !== null) {
+    const prop = property as FormSchemaProperty;
+    if (prop.type === "string") {
+      if (prop.format === "date-time") return "string";
+      return "string";
+    }
+    if (prop.type === "integer" || prop.type === "number") return "number";
+    if (prop.type === "boolean") return "boolean";
+    if (prop.type === "array") {
+      const itemType = getTypeScriptType(prop.items);
+      return `${itemType}[]`;
+    }
+    if (prop.type === "object") return "object";
+  }
+  return "unknown";
 };
 
 export const jsonToZod = (json: unknown, rootName = "Root"): string => {

--- a/src/widgets/api-list/module/hooks/useGetApiList.ts
+++ b/src/widgets/api-list/module/hooks/useGetApiList.ts
@@ -11,36 +11,62 @@ interface GetApiListProps {
   setPathInfo: (pathInfo: Path) => void;
 }
 
+const MAX_RETRIES = 3;
+const INITIAL_DELAY = 1000;
+
 const useGetApiList = ({ setApiList, setPathInfo }: GetApiListProps) => {
   const [loading, setLoading] = useState(true);
+
   const checkIfReceiverIsReady = (
     tabId: number,
-    callback: (isReady: boolean) => void
+    callback: (isReady: boolean) => void,
+    retryCount = 0,
+    delay = INITIAL_DELAY
   ) => {
-    chrome.tabs.sendMessage<{ message: string }, { data: boolean }>(
-      tabId,
-      { message: "READY" },
-      (response) => {
-        if (chrome.runtime.lastError) {
-          setTimeout(() => checkIfReceiverIsReady(tabId, callback), 1000);
-          setLoading(false);
-        } else {
-          callback(response.data);
-        }
+    if (retryCount >= MAX_RETRIES) {
+      console.error("retry exceed max retries");
+      setLoading(false);
+      callback(false);
+      return;
+    }
+
+    chrome.tabs.sendMessage(tabId, { message: "READY" }, (response) => {
+      if (chrome.runtime.lastError) {
+        const nextDelay = delay * 1.5;
+        setTimeout(
+          () =>
+            checkIfReceiverIsReady(tabId, callback, retryCount + 1, nextDelay),
+          delay
+        );
+      } else {
+        setLoading(false);
+        callback(response.data);
       }
-    );
+    });
   };
 
   const getApiList = (
     tabId: number,
-    callback: (data: GET_API_LIST_RESULT) => void
+    callback: (data: GET_API_LIST_RESULT) => void,
+    retryCount = 0,
+    delay = INITIAL_DELAY
   ) => {
+    if (retryCount >= MAX_RETRIES) {
+      console.error("getApiList: retry exceed max retries");
+      setLoading(false);
+      return;
+    }
+
     chrome.tabs.sendMessage(
       tabId,
       { message: "GET_SWAGGER_LIST" },
       (response) => {
         if (chrome.runtime.lastError) {
-          setTimeout(() => getApiList(tabId, callback), 1000);
+          const nextDelay = delay * 1.5;
+          setTimeout(
+            () => getApiList(tabId, callback, retryCount + 1, nextDelay),
+            delay
+          );
         } else {
           callback(response.data);
         }
@@ -56,6 +82,7 @@ const useGetApiList = ({ setApiList, setPathInfo }: GetApiListProps) => {
       return;
     }
     setLoading(true);
+
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       checkIfReceiverIsReady(tabs[0].id, (isReady) => {
         if (isReady) {
@@ -64,14 +91,12 @@ const useGetApiList = ({ setApiList, setPathInfo }: GetApiListProps) => {
             setPathInfo(data.path);
             setState("loaded");
           });
-          setTimeout(() => {
-            setLoading(false);
-          }, 500);
         } else {
           console.error("Error: Receiving end does not exist");
         }
       });
     });
+
     // Context menu를 위한 코드
     chrome.tabs.query({ active: true, currentWindow: false }, (tabs) => {
       if (tabs.length === 0) return;
@@ -83,9 +108,6 @@ const useGetApiList = ({ setApiList, setPathInfo }: GetApiListProps) => {
               setPathInfo(data.path);
               setState("loaded");
             });
-            setTimeout(() => {
-              setLoading(false);
-            }, 500);
           }
         })
       );

--- a/src/widgets/code-block/ui/code-block-modal/CodeBlockView.tsx
+++ b/src/widgets/code-block/ui/code-block-modal/CodeBlockView.tsx
@@ -1,6 +1,5 @@
 import { ForwardRefRenderFunction, forwardRef } from "react";
 
-import { Mode } from "@/pages/popup/pages/RequestPage/RequestPage";
 import Button from "@/shared/ui/Button";
 import { vars } from "@/shared/ui/styles/theme.css";
 import { IoMdClose as CloseIcon } from "react-icons/io";
@@ -12,7 +11,8 @@ interface CodeBlockProps {
   description: string;
   descriptionColor?: keyof typeof vars.color;
   code: string;
-  mode: Mode;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  mode: "base" | (string & {});
   isModal?: boolean;
   onClose?: () => void;
   onClickBack?: () => void;
@@ -55,16 +55,16 @@ const CodeBlockView: ForwardRefRenderFunction<
               <>
                 <button
                   onClick={() => {
-                    mode === "RESPONSE" && onClose && onClose();
-                    mode !== "RESPONSE" && onClickBack && onClickBack();
+                    mode === "base" && onClose && onClose();
+                    mode !== "base" && onClickBack && onClickBack();
                   }}
                   className={codeBlockModalStyles.iconButton}
                   type="button"
                 >
-                  {mode === "RESPONSE" && (
+                  {mode === "base" && (
                     <CloseIcon size={24} color={vars.color.white} />
                   )}
-                  {mode !== "RESPONSE" && (
+                  {mode !== "base" && (
                     <BackIcon size={24} color={vars.color.white} />
                   )}
                 </button>
@@ -79,7 +79,7 @@ const CodeBlockView: ForwardRefRenderFunction<
                 </h3>
               </>
             )}
-            {!isModal && mode !== "RESPONSE" && (
+            {!isModal && mode !== "base" && (
               <>
                 <button
                   onClick={() => {

--- a/src/widgets/setting/ui/setting-modal/SettingModal.tsx
+++ b/src/widgets/setting/ui/setting-modal/SettingModal.tsx
@@ -2,6 +2,7 @@
 import Button from "@/shared/ui/Button";
 import Modal from "@/shared/ui/Modal";
 import { vars } from "@/shared/ui/styles/theme.css";
+import { noop } from "@/shared/util/common";
 import LogoImg from "@assets/img/react-query-logo.png";
 import { IoIosSettings as SettingIcon } from "react-icons/io";
 import { settingModalStyle } from "./settingModal.css";
@@ -21,7 +22,7 @@ const SettingModal = ({
     <Modal>
       <Modal.Trigger
         as={
-          <button onClick={() => {}}>
+          <button onClick={noop}>
             <SettingIcon size={24} color={vars.color.lightGreen} />
           </button>
         }

--- a/utils/reload/initReloadServer.js
+++ b/utils/reload/initReloadServer.js
@@ -1,13 +1,13 @@
-import chokidar from "chokidar";
-import { clearTimeout } from "timers";
-import { WebSocketServer } from "ws";
+import { WebSocketServer } from 'ws';
+import chokidar from 'chokidar';
+import { clearTimeout } from 'timers';
 
 function debounce(callback, delay) {
-  let timer;
-  return function (...args) {
-    clearTimeout(timer);
-    timer = setTimeout(() => callback(...args), delay);
-  };
+    let timer;
+    return function (...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => callback(...args), delay);
+    };
 }
 
 const LOCAL_RELOAD_SOCKET_PORT = 8081;
@@ -17,60 +17,55 @@ const UPDATE_REQUEST_MESSAGE = "do_update";
 const UPDATE_COMPLETE_MESSAGE = "done_update";
 
 class MessageInterpreter {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {}
-  static send(message) {
-    return JSON.stringify(message);
-  }
-  static receive(serializedMessage) {
-    return JSON.parse(serializedMessage);
-  }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor() { }
+    static send(message) {
+        return JSON.stringify(message);
+    }
+    static receive(serializedMessage) {
+        return JSON.parse(serializedMessage);
+    }
 }
 
 const clientsThatNeedToUpdate = new Set();
 function initReloadServer() {
-  const wss = new WebSocketServer({ port: LOCAL_RELOAD_SOCKET_PORT });
-  wss.on("listening", () =>
-    console.log(`[HRS] Server listening at ${LOCAL_RELOAD_SOCKET_URL}`)
-  );
-  wss.on("connection", (ws) => {
-    clientsThatNeedToUpdate.add(ws);
-    ws.addEventListener("close", () => clientsThatNeedToUpdate.delete(ws));
-    ws.addEventListener("message", (event) => {
-      const message = MessageInterpreter.receive(String(event.data));
-      if (message.type === UPDATE_COMPLETE_MESSAGE) {
-        ws.close();
-      }
+    const wss = new WebSocketServer({ port: LOCAL_RELOAD_SOCKET_PORT });
+    wss.on("listening", () => console.log(`[HRS] Server listening at ${LOCAL_RELOAD_SOCKET_URL}`));
+    wss.on("connection", (ws) => {
+        clientsThatNeedToUpdate.add(ws);
+        ws.addEventListener("close", () => clientsThatNeedToUpdate.delete(ws));
+        ws.addEventListener("message", (event) => {
+            const message = MessageInterpreter.receive(String(event.data));
+            if (message.type === UPDATE_COMPLETE_MESSAGE) {
+                ws.close();
+            }
+        });
     });
-  });
 }
 /** CHECK:: src file was updated **/
 const debounceSrc = debounce(function (path) {
-  // Normalize path on Windows
-  const pathConverted = path.replace(/\\/g, "/");
-  clientsThatNeedToUpdate.forEach((ws) =>
-    ws.send(
-      MessageInterpreter.send({
+    // Normalize path on Windows
+    const pathConverted = path.replace(/\\/g, "/");
+    clientsThatNeedToUpdate.forEach((ws) => ws.send(MessageInterpreter.send({
         type: UPDATE_PENDING_MESSAGE,
         path: pathConverted,
-      })
-    )
-  );
+    })));
 }, 200);
 chokidar.watch("src").on("all", (event, path) => debounceSrc(path));
 /** CHECK:: build was completed **/
 const debounceDist = debounce(() => {
-  clientsThatNeedToUpdate.forEach((ws) => {
-    ws.send(MessageInterpreter.send({ type: UPDATE_REQUEST_MESSAGE }));
-  });
+    clientsThatNeedToUpdate.forEach((ws) => {
+        ws.send(MessageInterpreter.send({ type: UPDATE_REQUEST_MESSAGE }));
+    });
 }, 200);
 chokidar.watch("dist").on("all", (event) => {
-  // Ignore unlink, unlinkDir and change events
-  // that happen in beginning of build:watch and
-  // that will cause ws.send() if it takes more than 200ms
-  // to build (which it might). This fixes:
-  // https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/100
-  if (event !== "add" && event !== "addDir") return;
-  debounceDist();
+    // Ignore unlink, unlinkDir and change events
+    // that happen in beginning of build:watch and
+    // that will cause ws.send() if it takes more than 200ms
+    // to build (which it might). This fixes:
+    // https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/100
+    if (event !== "add" && event !== "addDir")
+        return;
+    debounceDist();
 });
 initReloadServer();


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #183
- PR의 메인 내용

<br>

1. 코드 개선
 - api 무한 호출에 대한 최대 호출 예외처리 로직 추가

2. swagger 스키마 기반 데이터 추출 기능 및 UI 추가
 


## 🔨 작업 사항 (필수)


 1. `DetailSchema` 인터페이스 추가 (`src/entities/swagger/types/index.ts`)
      - Request/Response 타입 정보를 추가로 파싱하여 스키마 정보를 추가로 저장합니다.
      - `extractTypeSchemaInfo ` 함수를 통해 스키마 정보 추출 (`apiTransform.ts`)
      
2. `ApiListPage` 상태 추가 및 reducer분리 (`src/features/request-api/module/requestReducer.ts`)
    - 기존에는 항상 API의 respnose에 대응하는 코드를 처리헀다면, 스키마 정보로부터 코드를 추출하는 로직을 추가하였습니다
       - ApiMode와 SchemaMode로 모드별 상태 분리
       -  ```tsx
             // API 응답 상태: 실제 API 호출 결과를 처리
          { type: "API_RESPONSE"; mode: ApiMode }

          // 스키마 정의 상태: Swagger에서 추출한 타입 정보를 처리  
          { type: "SCHEMA_DEFINITION"; schemaType: SchemaType; mode: SchemaMode }
          ```


3. `getApiList`파일을 import할 수 없는 이슈를 해결하고자 import 코드 로직 내부로 이동
 
<br>

## 📸 스크린샷 (선택) 



### UI 추가사항 (버튼 2개 추가)
<img width="565" alt="image" src="https://github.com/user-attachments/assets/495556ee-3ebb-4bba-ad85-6a56314e2636" />



### request
![req](https://github.com/user-attachments/assets/75c4251a-5e4c-4ede-ba2b-c893f8c2638b)


## response
![Jun-23-2025 20-23-24](https://github.com/user-attachments/assets/689feb54-4cbb-4cc5-8195-aedd53b62d5e)

